### PR TITLE
Add the ability to associate app users to form templates when importing.

### DIFF
--- a/apps/odk_publish/models.py
+++ b/apps/odk_publish/models.py
@@ -205,6 +205,17 @@ class AppUser(AbstractBaseModel):
             for template_variable in variables
         ]
 
+    @property
+    def form_templates(self):
+        """Get a list of the form_id_base values from the user's related FormTemplates.
+        Used by the "form_templates" column in the files for exporting/importing AppUsers.
+        """
+        # Prevent `ValueError('AppUser' instance needs to have a primary key
+        # value before this relationship can be used)`
+        if self.pk:
+            return [obj.form_template.form_id_base for obj in self.app_user_forms.all()]
+        return []
+
 
 class AppUserFormTemplate(AbstractBaseModel):
     app_user = models.ForeignKey(AppUser, on_delete=models.CASCADE, related_name="app_user_forms")

--- a/apps/odk_publish/views.py
+++ b/apps/odk_publish/views.py
@@ -161,9 +161,7 @@ def app_user_export(request, odk_project_pk):
     form = AppUserExportForm([resource], data=request.POST or None)
     if request.method == "POST" and form.is_valid():
         export_format = form.cleaned_data["format"]
-        dataset = resource.export(
-            request.odk_project.app_users.prefetch_related("app_user_template_variables")
-        )
+        dataset = resource.export()
         data = export_format.export_data(dataset)
         filename = f"app_users_{odk_project_pk}_{localdate()}.{export_format.get_extension()}"
         return HttpResponse(

--- a/tests/odk_publish/test_import_export.py
+++ b/tests/odk_publish/test_import_export.py
@@ -26,6 +26,8 @@ class TestAppUserResource:
             central_server=central_server,
         )
         project.template_variables.set(template_variables)
+        project.form_templates.create(form_id_base="template1")
+        project.form_templates.create(form_id_base="template2")
         return project
 
     @pytest.fixture
@@ -37,6 +39,8 @@ class TestAppUserResource:
             central_server=myodkcloud,
         )
         project.template_variables.set(template_variables)
+        project.form_templates.create(form_id_base="template3")
+        project.form_templates.create(form_id_base="template4")
         return project
 
     @pytest.fixture
@@ -48,6 +52,8 @@ class TestAppUserResource:
         )
         for var in project.template_variables.all():
             app_user.app_user_template_variables.create(template_variable=var, value="test")
+        for template in project.form_templates.order_by("form_id_base"):
+            app_user.app_user_forms.create(form_template=template)
         return app_user
 
     def test_export(self, project, other_project, template_variables):
@@ -60,7 +66,16 @@ class TestAppUserResource:
                 project=project if center_id % 2 else other_project,
                 central_id=center_id - 11000,
             )
-            export_values = [app_user.id, app_user.name, app_user.central_id]
+            template_ids = []
+            for template in app_user.project.form_templates.order_by("form_id_base"):
+                app_user.app_user_forms.create(form_template=template)
+                template_ids.append(template.form_id_base)
+            export_values = [
+                app_user.id,
+                app_user.name,
+                app_user.central_id,
+                ",".join(template_ids),
+            ]
             for var, value in zip(
                 template_variables,
                 (center_id, f"Center {center_id}", f"key{center_id}", f"pass{center_id}"),
@@ -73,7 +88,7 @@ class TestAppUserResource:
                 expected_export_values.add(tuple(str(i) for i in export_values))
 
         resource = import_export.AppUserResource(project)
-        dataset = resource.export(project.app_users.all())
+        dataset = resource.export()
 
         # Only data for the selected project should be exported
         assert len(dataset) == 5
@@ -81,6 +96,7 @@ class TestAppUserResource:
             "id",
             "name",
             "central_id",
+            "form_templates",
             "center_id",
             "center_label",
             "public_key",
@@ -98,14 +114,15 @@ class TestAppUserResource:
         )
         assert models.AppUser.objects.count() == 2
         assert models.AppUserTemplateVariable.objects.count() == project.template_variables.count()
+        assert models.AppUserFormTemplate.objects.count() == 2
 
         csv_data = (
-            "id,name,central_id,center_id,center_label,public_key,manager_password\n"
-            f"{app_user.id},11031,31,11031,Center 11031,key11031,pass11031\n"
-            f"{app_user2.id},11033,33,11033,Center 11033,key11033,pass11033\n"
-            ",11035,35,11035,Center 11035,key11035,pass11035\n"
-            ",11037,37,11037,Center 11037,key11037,pass11037\n"
-            ",11039,39,11039,Center 11039,key11039,pass11039\n"
+            "id,name,central_id,form_templates,center_id,center_label,public_key,manager_password\n"
+            f"{app_user.id},11031,31,template1,11031,Center 11031,key11031,pass11031\n"
+            f"{app_user2.id},11033,33,template2,11033,Center 11033,key11033,pass11033\n"
+            ',11035,35,"template1,template2",11035,Center 11035,key11035,pass11035\n'
+            ",11037,37,template2,11037,Center 11037,key11037,pass11037\n"
+            ",11039,39, ,11039,Center 11039,key11039,pass11039\n"
         )
         dataset = Dataset().load(csv_data)
         resource = import_export.AppUserResource(project)
@@ -119,11 +136,13 @@ class TestAppUserResource:
         assert (
             models.AppUserTemplateVariable.objects.count() == project.template_variables.count() * 5
         )
+        assert models.AppUserFormTemplate.objects.count() == 5
 
         # Make sure user data has been added / updated
         for row in dataset.dict:
             pk = row.pop("id")
             name = row.pop("name")
+            form_templates = row.pop("form_templates")
             if pk:
                 # User was already in the DB
                 app_user = models.AppUser.objects.get(pk=pk)
@@ -140,6 +159,9 @@ class TestAppUserResource:
                 )
                 == row
             )
+            assert set(app_user.form_templates) == {
+                t for i in form_templates.split(",") if (t := i.strip())
+            }
 
     def test_cannot_import_other_projects_users(self, app_user, other_project):
         app_user2 = models.AppUser.objects.create(
@@ -148,9 +170,9 @@ class TestAppUserResource:
             central_id=2,
         )
         csv_data = (
-            "id,name,central_id,center_id,center_label,public_key,manager_password\n"
-            f"{app_user.id},11031,31,11031,Center 11031,key11031,pass11031\n"
-            f"{app_user2.id},11033,33,11033,Center 11033,key11033,pass11033"
+            "id,name,central_id,form_templates,center_id,center_label,public_key,manager_password\n"
+            f"{app_user.id},11031,31,template1,11031,Center 11031,key11031,pass11031\n"
+            f"{app_user2.id},11033,33,template3,11033,Center 11033,key11033,pass11033"
         )
         dataset = Dataset().load(csv_data)
         resource = import_export.AppUserResource(app_user.project)
@@ -174,18 +196,22 @@ class TestAppUserResource:
             list(app_user.app_user_template_variables.values_list("value", flat=True))
             == ["test"] * 4
         )
+        assert list(
+            app_user.app_user_forms.values_list("form_template__form_id_base", flat=True)
+        ) == ["template1", "template2"]
 
         app_user2.refresh_from_db()
         assert app_user2.name == "67890"
         assert app_user2.central_id == 2
         assert app_user2.app_user_template_variables.count() == 0
+        assert app_user2.app_user_forms.count() == 0
 
     def test_blank_template_variables_deleted(self, app_user):
         assert app_user.app_user_template_variables.count() == 4
 
         csv_data = (
-            "id,name,central_id,center_id,center_label,public_key,manager_password\n"
-            f"{app_user.id},11031,31,11031,Center 11031,,"
+            "id,name,central_id,form_templates,center_id,center_label,public_key,manager_password\n"
+            f"{app_user.id},11031,31,template1,11031,Center 11031,,"
         )
 
         dataset = Dataset().load(csv_data)
@@ -207,16 +233,18 @@ class TestAppUserResource:
         assert variables["center_label"] == "Center 11031"
 
     def test_validation_errors(self, app_user):
-        # CSV with 5 invalid rows and 1 valid row
+        # CSV with 6 invalid rows and 2 valid rows
         csv_data = (
-            "id,name,central_id,center_id,center_label,public_key,manager_password\n"
-            f"{app_user.id},,,,,,\n"  # Existing user has no name
-            ",,1,,,,\n"  # New user has central_id but no name
-            ",new1,xx,,,,\n"  # New user has a non-integer central_id
-            f",new2,2,{'1' * 1025},,,\n"  # New user has a center_id with more than 1024 characters
-            f",{app_user.name},2,,,,\n"  # New user has the same name as the existing user
-            ",new3,3,,,,\n"  # New user has both name and central_id, so is valid
-            ",new4,,,,,\n"  # New user with name only is valid
+            "id,name,central_id,form_templates,center_id,center_label,public_key,manager_password\n"
+            f"{app_user.id},,,,,,,\n"  # Existing user has no name
+            ",,1,,,,,\n"  # New user has central_id but no name
+            ",new1,xx,,,,,\n"  # New user has a non-integer central_id
+            f",new2,2,,{'1' * 1025},,,\n"  # New user has a center_id with more than 1024 characters
+            f",{app_user.name},2,,,,,\n"  # New user has the same name as the existing user
+            ",new5,5,nonexistent,,,,\n"  # New user with invalid template ID
+            # Valid rows
+            ",new3,3,,,,,\n"  # New user has both name and central_id, so is valid
+            ",new4,,,,,,\n"  # New user with name only is valid
         )
 
         dataset = Dataset().load(csv_data)
@@ -235,6 +263,14 @@ class TestAppUserResource:
             (3, {"central_id": ["Value must be an integer."]}),
             (4, {"center_id": ["Ensure this value has at most 1024 characters (it has 1025)."]}),
             (5, {"__all__": ["App user with this Project and Name already exists."]}),
+            (
+                6,
+                {
+                    "form_templates": [
+                        "The following form templates do not exist on the project: nonexistent"
+                    ]
+                },
+            ),
         ]
 
         assert result.has_validation_errors()


### PR DESCRIPTION
This PR adds  a `form_templates` column to the export with a serialized list of `FormTemplate.form_id_base` values like this:

![410642214-02ca7afc-eea6-4b67-822d-598f3a47451b](https://github.com/user-attachments/assets/dffde45d-eebb-484e-a241-4127e71680e5)

It also adds the ability to create/delete `AppUserFormTemplate` objects based on the values in that column during import.