### PR TITLE
Add the ability to use Gunicorn instead of Daphne to run the server in a Docker container.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, separate-wsgi-asgi]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main, separate-wsgi-asgi]
+    branches: [main]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,4 +82,4 @@ USER ${APP_USER}:${APP_USER}
 ENTRYPOINT ["/code/docker-entrypoint.sh"]
 
 # Start uWSGI
-CMD ["newrelic-admin", "run-program", "daphne", "config.asgi:application", "--bind", "0.0.0.0", "--port", "8000"]
+CMD ["/code/run_server.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,5 +81,5 @@ USER ${APP_USER}:${APP_USER}
 # Uncomment after creating your docker-entrypoint.sh
 ENTRYPOINT ["/code/docker-entrypoint.sh"]
 
-# Start uWSGI
+# Start a Gunicorn server if a USE_GUNICORN environment variable is set, else start a Daphne server
 CMD ["/code/run_server.sh"]

--- a/apps/odk_publish/views.py
+++ b/apps/odk_publish/views.py
@@ -258,3 +258,10 @@ def app_user_import(request, odk_project_pk):
         "confirm": isinstance(form, AppUserConfirmImportForm),
     }
     return render(request, "odk_publish/app_user_import.html", context)
+
+
+def websockets_server_health(request):
+    """When using separate ASGI and WSGI deployments, this can be used for health checks
+    for the ASGI (Websockets) server.
+    """
+    return HttpResponse("OK")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -43,7 +43,6 @@ LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/accounts/login/"
 
 INSTALLED_APPS = [
-    "daphne",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -70,6 +69,9 @@ INSTALLED_APPS = [
     "apps.tailscale",
     "apps.users",
 ]
+
+if not os.getenv("USE_GUNICORN"):
+    INSTALLED_APPS.insert(0, "daphne")
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,10 +20,13 @@ from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import TemplateView
 
+from apps.odk_publish.views import websockets_server_health
+
 urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("admin/", admin.site.urls),
     path("odk/", include("apps.odk_publish.urls", namespace="odk_publish")),
+    path("ws/health/", websockets_server_health),
     path(r"", TemplateView.as_view(template_name="home.html"), name="home"),
 ]
 

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -x
+
+if [ "$USE_GUNICORN" ]; then
+    newrelic-admin run-program gunicorn config.wsgi --bind 0.0.0.0 --config python:config.gunicorn
+else
+    newrelic-admin run-program daphne config.asgi:application --bind 0.0.0.0 --port 8000
+fi


### PR DESCRIPTION
This PR adds the ability to use Gunicorn instead of Daphne to run the server in a Docker container. To use Gunicorn, set the `USE_GUNICORN` environment variable.