### PR TITLE
Do not log an error to Sentry if a variable is not in the Google Sheet.

### DIFF
--- a/apps/odk_publish/consumers.py
+++ b/apps/odk_publish/consumers.py
@@ -36,7 +36,10 @@ class PublishTemplateConsumer(WebsocketConsumer):
             event_data = json.loads(text_data)
             self.publish_form_template(event_data=event_data)
         except Exception as e:
-            logger.exception("Error publishing form")
+            if isinstance(e, LookupError):
+                logger.debug("Error publishing form", exc_info=True)
+            else:
+                logger.exception("Error publishing form")
             tbe = traceback.TracebackException.from_exception(exc=e, compact=True)
             message = "".join(tbe.format())
             # If the error is from ODK Central, format the error message for easier reading


### PR DESCRIPTION
This PR prevents logging the `LookupError` added in https://github.com/caktus/odk-publish/pull/21/ to Sentry.