### PR TITLE
Add a message about numeric values during app user import.

### DIFF
--- a/config/templates/odk_publish/app_user_import.html
+++ b/config/templates/odk_publish/app_user_import.html
@@ -91,6 +91,20 @@
                     <p class="mb-1 dark:text-gray-400">
                         {% trans "Please correct these errors in your data where possible, then reupload it using the form above." %}
                     </p>
+                    <div class="flex items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300"
+                         role="alert">
+                        <svg class="shrink-0 inline w-4 h-4 me-3"
+                             aria-hidden="true"
+                             xmlns="http://www.w3.org/2000/svg"
+                             fill="currentColor"
+                             viewBox="0 0 20 20">
+                            <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
+                        </svg>
+                        <span class="sr-only">Info</span>
+                        <div>
+                            If some numeric values are not displayed correctly here, consider setting the correct number format for those values in your original document, then try importing it again.
+                        </div>
+                    </div>
                     <table class="text-left w-full h-full text-sm text-gray-500 dark:text-gray-400 dark:bg-gray-800">
                         <thead class="text-xs text-gray-700 uppercase bg-primary-100 dark:bg-gray-700 dark:text-gray-400">
                             <tr>
@@ -139,6 +153,20 @@
             {% endif %}
         {% else %}
             <h3 class="font-semibold text-gray-900 dark:text-white mb-0.5">{% trans "Preview" %}</h3>
+            <div class="flex items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300"
+                 role="alert">
+                <svg class="shrink-0 inline w-4 h-4 me-3"
+                     aria-hidden="true"
+                     xmlns="http://www.w3.org/2000/svg"
+                     fill="currentColor"
+                     viewBox="0 0 20 20">
+                    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
+                </svg>
+                <span class="sr-only">Info</span>
+                <div>
+                    If some numeric values are not displayed correctly here, consider setting the correct number format for those values in your original document, then try importing it again.
+                </div>
+            </div>
             <table class="text-left w-full h-full text-sm text-gray-500 dark:text-gray-400 dark:bg-gray-800">
                 <thead class="text-xs text-gray-700 uppercase bg-primary-100 dark:bg-gray-700 dark:text-gray-400">
                     <tr>

--- a/tests/odk_publish/test_views.py
+++ b/tests/odk_publish/test_views.py
@@ -1,14 +1,8 @@
 import json
-import os
-import shutil
-from io import StringIO
 
 import pytest
 from django.urls import reverse
-from django.conf import settings
 from django.db.models import Q
-from import_export.formats.base_formats import CSV
-from import_export.tmp_storages import MediaStorage
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers.data import JsonLexer
@@ -22,8 +16,6 @@ from tests.odk_publish.factories import (
 )
 from apps.odk_publish.etl.odk.constants import DEFAULT_COLLECT_SETTINGS
 from apps.odk_publish.etl.odk.publish import ProjectAppUserAssignment
-from apps.odk_publish.forms import AppUserConfirmImportForm, AppUserImportForm
-from apps.odk_publish.models import AppUser
 
 
 @pytest.mark.django_db
@@ -80,98 +72,6 @@ class TestPublishTemplate(ViewTestBase):
         assert response.status_code == 200
         # Check that the response triggers the WebSocket connection
         assert 'hx-ws="send"' in str(response.content)
-
-
-class TestImport(ViewTestBase):
-    """Test the AppUser import process."""
-
-    @pytest.fixture
-    def url(self, project):
-        return reverse(
-            "odk_publish:app-users-import",
-            kwargs={"odk_project_pk": project.pk},
-        )
-
-    @pytest.fixture
-    def csv_data(self):
-        """Valid CSV import data with one new user."""
-        return "id,name,central_id,form_templates\n,newuser,,"
-
-    def teardown_class(cls):
-        shutil.rmtree(os.path.join(settings.MEDIA_ROOT, "django-import-export"))
-
-    def test_valid_upload(self, client, url, user, csv_data):
-        """Ensure the review page is shown after a valid import file is uploaded."""
-        data = {"format": 0, "import_file": StringIO(csv_data)}
-        response = client.post(url, data=data)
-        assert response.status_code == 200
-        assert isinstance(response.context["form"], AppUserConfirmImportForm)
-        assert (
-            "Below is a preview of data to be imported. If you are satisfied "
-            "with the results, click 'Confirm import'."
-        ) in response.content.decode()
-        assert len(response.context["result"].valid_rows()) == 1
-        # The user should not be created yet
-        assert AppUser.objects.count() == 0
-        # The CSV data should be saved in a temp file
-        import_format = CSV("utf-8-sig")
-        tmp_storage = MediaStorage(
-            name=response.context["form"].initial["import_file_name"],
-            encoding=import_format.encoding,
-            read_mode=import_format.get_read_mode(),
-        )
-        assert tmp_storage.read().decode(import_format.encoding) == csv_data
-
-    def test_import_confirmed(self, client, url, user, csv_data, project):
-        """Ensure confirming the import in the review page updates users."""
-        # Save the CSV data in a temp file, as would happen when a valid file is uploaded
-        import_format = CSV("utf-8-sig")
-        tmp_storage = MediaStorage(
-            encoding=import_format.encoding,
-            read_mode=import_format.get_read_mode(),
-        )
-        tmp_storage.save(csv_data)
-        # Submit a form for confirming the import
-        data = {
-            "import_file_name": tmp_storage.name,
-            "original_file_name": "test.csv",
-            "format": 0,
-            "resource": "",
-        }
-        response = client.post(url, data=data, follow=True)
-        # A new user is created and there's a redirect to the user list page
-        # with a success message
-        assert response.status_code == 200
-        assert AppUser.objects.count() == 1
-        assert response.redirect_chain == [
-            (reverse("odk_publish:app-user-list", args=[project.id]), 302)
-        ]
-        assert (
-            "Import finished successfully, with 1 new and 0 updated app users."
-            in response.content.decode()
-        )
-
-    def test_invalid_upload(self, client, url, user, csv_data, project):
-        """Ensure form validation errors are displayed in case of invalid data in the upload."""
-        # Add a row with an invalid central_id
-        csv_data += "\n,newuser2,xx,"
-        data = {"format": 0, "import_file": StringIO(csv_data)}
-        response = client.post(url, data=data)
-        response_content = response.content.decode()
-        expected_error = "Value must be an integer."
-        result = response.context["result"]
-
-        assert response.status_code == 200
-        assert isinstance(response.context["form"], AppUserImportForm)
-        assert (
-            "Please correct these errors in your data where possible, then reupload "
-            "it using the form above."
-        ) in response_content
-        assert len(result.invalid_rows) == 1
-        assert result.invalid_rows[0].field_specific_errors["central_id"] == [expected_error]
-        assert expected_error in response_content
-        # A user should not be created
-        assert AppUser.objects.count() == 0
 
 
 class TestAppUserDetail(ViewTestBase):


### PR DESCRIPTION
This PR adds a message in the app user import preview page: "If some numeric values are not displayed correctly here, consider setting the correct number format for those values in your original document, then try importing it again."

This is meant to help users fix issues such as integer values being imported as floating point values when importing .xlsx files edited in Google Sheets.