### PR TITLE
Add form template version table to the form template detail page.

### DIFF
--- a/apps/odk_publish/tables.py
+++ b/apps/odk_publish/tables.py
@@ -1,6 +1,6 @@
 import django_tables2 as tables
 
-from .models import FormTemplate
+from .models import FormTemplate, FormTemplateVersion
 
 
 class FormTemplateTable(tables.Table):
@@ -22,6 +22,21 @@ class FormTemplateTable(tables.Table):
     class Meta:
         model = FormTemplate
         fields = ["title_base", "form_id_base"]
+        template_name = "patterns/tables/table.html"
+        attrs = {"th": {"scope": "col", "class": "px-4 py-3 whitespace-nowrap"}}
+        orderable = False
+
+
+class FormTemplateVersionTable(tables.Table):
+    """A table for displaying the version history for a form template."""
+
+    version = tables.Column(verbose_name="Version number")
+    modified_at = tables.DateColumn(verbose_name="Date published")
+    published_by = tables.Column(accessor="user__get_full_name")
+
+    class Meta:
+        model = FormTemplateVersion
+        fields = ["version", "modified_at"]
         template_name = "patterns/tables/table.html"
         attrs = {"th": {"scope": "col", "class": "px-4 py-3 whitespace-nowrap"}}
         orderable = False

--- a/apps/odk_publish/views.py
+++ b/apps/odk_publish/views.py
@@ -41,7 +41,7 @@ from .forms import (
 from .import_export import AppUserResource
 from .models import FormTemplateVersion, FormTemplate, AppUser
 from .nav import Breadcrumbs
-from .tables import FormTemplateTable
+from .tables import FormTemplateTable, FormTemplateVersionTable
 
 
 logger = structlog.getLogger(__name__)
@@ -135,6 +135,9 @@ def form_template_detail(
         ),
         pk=form_template_id,
     )
+    versions_table = FormTemplateVersionTable(
+        data=form_template.latest_version, request=request, show_footer=False
+    )
     context = {
         "form_template": form_template,
         "form_template_app_users": form_template.app_user_forms.values_list(
@@ -147,6 +150,7 @@ def form_template_detail(
                 (form_template.title_base, "form-template-detail", [form_template.pk]),
             ],
         ),
+        "versions_table": versions_table,
     }
     return render(request, "odk_publish/form_template_detail.html", context)
 

--- a/config/templates/odk_publish/form_template_detail.html
+++ b/config/templates/odk_publish/form_template_detail.html
@@ -34,6 +34,8 @@
                 <a href="{% url 'odk_publish:edit-form-template' request.organization.slug request.odk_project.id form_template.id %}"
                    class="btn btn-outline ml-4">Edit Form Template</a>
             </div>
+            <h3 class="font-semibold text-xl text-gray-900 dark:text-white mb-2 mt-6">Version History</h3>
+            {% include "patterns/tables/table-partial.html" with table=versions_table %}
         </div>
         <!-- Column -->
         <dl>

--- a/tests/odk_publish/test_views.py
+++ b/tests/odk_publish/test_views.py
@@ -1,10 +1,12 @@
 import json
 
 import pytest
+from django_tables2 import Table
 from django.urls import reverse
 from django.conf import settings
 from django.db.models import Q
-from django.utils.timezone import now
+from django.utils.timezone import now, localtime
+from django.utils.formats import date_format
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers.data import JsonLexer
@@ -13,6 +15,7 @@ from tests.odk_publish.factories import (
     AppUserFactory,
     AppUserFormTemplateFactory,
     FormTemplateFactory,
+    FormTemplateVersionFactory,
     OrganizationFactory,
     OrganizationInvitationFactory,
     ProjectFactory,
@@ -327,6 +330,48 @@ class TestEditFormTemplate(ViewTestBase):
             f"Successfully edited {form_template_values['title_base']}."
             in response.content.decode()
         )
+
+
+class TestFormTemplateDetail(ViewTestBase):
+    """Test the form template detail page."""
+
+    @pytest.fixture
+    def form_template(self, project):
+        form_template = FormTemplateFactory(project=project)
+        # Create 5 versions for the template
+        FormTemplateVersionFactory.create_batch(5, form_template=form_template)
+        return form_template
+
+    @pytest.fixture
+    def url(self, form_template):
+        return reverse(
+            "odk_publish:form-template-detail",
+            kwargs={
+                "organization_slug": form_template.project.organization.slug,
+                "odk_project_pk": form_template.project_id,
+                "form_template_id": form_template.id,
+            },
+        )
+
+    def test_get(self, client, url, user, form_template):
+        response = client.get(url)
+        assert response.status_code == 200
+        # Ensure the versions table is included in the context and it has the
+        # expected data
+        versions_table = response.context.get("versions_table")
+        assert isinstance(versions_table, Table)
+        rows = response.context["versions_table"].as_values()
+        assert next(rows) == ["Version number", "Date published", "Published by"]
+        assert list(rows) == [
+            [
+                i.version,
+                date_format(localtime(i.modified_at), settings.SHORT_DATE_FORMAT),
+                i.user.get_full_name(),
+            ]
+            for i in form_template.versions.order_by("-modified_at")
+        ]
+        # Ensure the table is rendered in the page
+        assert versions_table.as_html(response.wsgi_request) in response.content.decode()
 
 
 class TestAddAppUser(ViewTestBase):

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -43,7 +43,7 @@ class UserFactory(factory.django.DjangoModelFactory):
         """Create a social account for the user."""
         if not create:
             return
-        SocialTokenFactory(account__user=self, account__uid=fake.random_number())
+        SocialTokenFactory(account__user=self, account__uid=fake.unique.pyint())
 
 
 class SocialAccountFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
This PR adds a table to the form template detail page that lists all versions of the form template, including the version number, the date it was published, and the user who published it.

![2025-04-22_16-22](https://github.com/user-attachments/assets/ebed5779-ca1b-4e16-895d-cdea510543f9)
