### PR TITLE
Filter out system variables before setting template vars for render.

### DIFF
--- a/apps/odk_publish/etl/transform.py
+++ b/apps/odk_publish/etl/transform.py
@@ -29,7 +29,10 @@ def render_template_for_app_user(
 
     # Fill in the survey template variables
     variables = app_user.get_template_variables()
-    set_survey_template_variables(sheet=workbook["survey"], variables=variables)
+
+    # FILTER OUT system variables like 'admin_pw'
+    form_variables = [var for var in variables if var.name not in {"admin_pw"}]
+    set_survey_template_variables(sheet=workbook["survey"], variables=form_variables)
 
     # Detect static attachments in the survey sheet
     set_survey_attachments(sheet=workbook["survey"], attachments=attachments)


### PR DESCRIPTION
This PR fixes an error that arises when a user attempts to publish an ODK form after an `admin_pw` has been set. This fix filters out variables meant for system config before setting the variables and rendering the form template.

Once merged, this PR should close: https://github.com/hnec-vr/libya-elections/issues/4537

Before
![image](https://github.com/user-attachments/assets/487637a5-4881-4264-8e9c-293ebf9317b3)

After
![Screen Shot 2025-04-23 at 3 55 35 PM](https://github.com/user-attachments/assets/9ec9dab2-23a9-4aae-8fc4-7475b80e88d9)
