### PR TITLE
Fix TypeError occurring when importing new MDM Devices.

### DIFF
--- a/apps/mdm/tasks.py
+++ b/apps/mdm/tasks.py
@@ -205,6 +205,9 @@ def push_device_config(session: Session, device: Device):
 
     https://www.tinymdm.net/mobile-device-management/api/#put-/users/-id-
     """
+    if not device.raw_mdm_device:
+        logger.debug("New device. Cannot sync", device=device)
+        return
     logger.debug("Syncing device", device=device)
     if (device.app_user_name) and (
         app_user := AppUser.objects.filter(

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -223,6 +223,14 @@ class TestTasks:
             "devices": [device.device_id],
         }
 
+    def test_push_device_config_new_device(self, policy, set_tinymdm_env_vars):
+        """Ensures calling push_device_config() with a Device whose `raw_mdm_device` field
+        is not set does not raise a TypeError."""
+        device = DeviceFactory.build(policy=policy, raw_mdm_device=None)
+        device.save(push_to_mdm=False)
+        session = tasks.get_tinymdm_session()
+        tasks.push_device_config(session, device)
+
     def test_sync_policy(self, policy, devices, mocker, set_tinymdm_env_vars):
         """Ensure calling sync_policy() calls pull_devices() for the specified policy
         and push_device_config() for the policy's devices whose app_user_name field is set.


### PR DESCRIPTION
This PR fixes an exception (`TypeError: 'NoneType' object is not subscriptable`) that occurs when importing a new MDM device.