### PR TITLE
Fix PublishService.get_unique_version_by_form_id() returning a version that exists in the database.

### DIFF
--- a/apps/odk_publish/etl/load.py
+++ b/apps/odk_publish/etl/load.py
@@ -62,7 +62,8 @@ def publish_form_template(event: PublishTemplateEvent, user: User, send_message:
         project_id=form_template.project.central_id,
     )
     version = client.odk_publish.get_unique_version_by_form_id(
-        xml_form_id_base=form_template.form_id_base
+        xml_form_id_base=form_template.form_id_base,
+        form_template=form_template,
     )
     send_message(f"Generated version: {version}")
     # Download the template from Google Sheets

--- a/tests/odk_publish/etl/load/test_publish.py
+++ b/tests/odk_publish/etl/load/test_publish.py
@@ -137,7 +137,9 @@ class TestPublishFormTemplate:
         )
         publish_form_template(event=event, user=user, send_message=self.send_message)
         mock_get_users.assert_called_once()
-        mock_get_version.assert_called_once_with(xml_form_id_base=form_template.form_id_base)
+        mock_get_version.assert_called_once_with(
+            xml_form_id_base=form_template.form_id_base, form_template=form_template
+        )
         mock_create_or_update_form.assert_called_once()
         for call in mock_create_or_update_form.mock_calls:
             call.kwargs["xml_form_id"] = user_form1.xml_form_id

--- a/tests/odk_publish/etl/odk/test_publish_service.py
+++ b/tests/odk_publish/etl/odk/test_publish_service.py
@@ -9,6 +9,7 @@ from pyodk.errors import PyODKError
 
 from apps.odk_publish.etl.odk.publish import ProjectAppUserAssignment, Form
 from apps.odk_publish.etl.odk.client import ODKPublishClient
+from tests.odk_publish.factories import FormTemplateFactory, FormTemplateVersionFactory
 
 
 @pytest.fixture
@@ -367,3 +368,19 @@ class TestPublishServiceFormVersions:
             xml_form_id_base="myform"
         )
         assert next_version == expected
+
+    @pytest.mark.django_db
+    def test_get_next_form_version_with_db_check(self, forms, mocker, odk_client: ODKPublishClient):
+        """Ensure the get_unique_version_by_form_id method does not return a version
+        that exists in the DB if it's called with the form_template arg.
+        """
+        today = dt.datetime.today().strftime("%Y-%m-%d")
+        forms["myform_10000"].version = f"{today}-v1"
+        form_template = FormTemplateFactory(form_id_base="myform", project__central_id=1)
+        FormTemplateVersionFactory(form_template=form_template, version=f"{today}-v2")
+        mocker.patch.object(odk_client.odk_publish, "get_forms", return_value=forms)
+        next_version = odk_client.odk_publish.get_unique_version_by_form_id(
+            xml_form_id_base="myform",
+            form_template=form_template,
+        )
+        assert not form_template.versions.filter(version=next_version).exists()


### PR DESCRIPTION
This fixes an exception (`IntegrityError: duplicate key value violates unique constraint "unique_form_template_version"`) that occurs when publishing a form if `PublishService.get_unique_version_by_form_id()` returns a version that already exists in the database. This would happen if the form's `form_id_base` has been changed.