### PR TITLE
Set Device Deletion Schedule Default as Stopped

### DIFF
--- a/dagster_publish_mdm/definitions.py
+++ b/dagster_publish_mdm/definitions.py
@@ -24,7 +24,7 @@ tailscale_device_deletion_schedule = dg.ScheduleDefinition(
     target=dg.AssetSelection.groups("tailscale_device_prunning_assets")
     | dg.AssetSelection.assets("tailscale_device_snapshot"),
     cron_schedule="0 16 * * *",  # Once a day at 4PM UTC
-    default_status=dg.DefaultScheduleStatus.RUNNING,
+    default_status=dg.DefaultScheduleStatus.STOPPED,
 )
 
 defs = dg.Definitions(


### PR DESCRIPTION
This sets the `default_status=dg.DefaultScheduleStatus.STOPPED` as stopped. 

Since this dag is deployed to both caktuslab and LTT, if we have it defaulted to the Running status in both, both environments will attempt to delete the same devices at the same time, where one environment will end up throwing an error when the device no longer exists if the other has deleted it. 

This is a non-critical error, but it will unnecessarily be flagged by Sentry.

If we have it defaulted to Stopped, there will be a more conscience control of having it set to the Running status ideally on LTT. One can set it to run manually via the web UI.