### PR TITLE
Security: default SENTRY_SEND_DEFAULT_PII to False (VULN-005)

### DIFF
--- a/config/settings/deploy.py
+++ b/config/settings/deploy.py
@@ -70,7 +70,7 @@ CELERY_SEND_TASK_ERROR_EMAILS = True
 # SENTRY
 # ------------------------------------------------------------------------------
 SENTRY_DSN = os.getenv("SENTRY_DSN")
-SENTRY_SEND_DEFAULT_PII = os.getenv("SENTRY_SEND_DEFAULT_PII", "True") == "True"
+SENTRY_SEND_DEFAULT_PII = os.getenv("SENTRY_SEND_DEFAULT_PII", "False") == "True"
 if SENTRY_DSN:
     import sentry_sdk
 


### PR DESCRIPTION
Fixes #105.

## Summary

Changes the `SENTRY_SEND_DEFAULT_PII` default in `config/settings/deploy.py` from `"True"` to `"False"` so user PII is not forwarded to Sentry unless an operator explicitly opts in.

## Diff

```diff
 SENTRY_SEND_DEFAULT_PII = os.getenv("SENTRY_SEND_DEFAULT_PII", "False") == "True"
```

## Impact

Any deployment that configures `SENTRY_DSN` without explicitly setting `SENTRY_SEND_DEFAULT_PII` will now send **no** PII to Sentry by default. Operators who want PII forwarding must set `SENTRY_SEND_DEFAULT_PII=True` in their environment.