### PR TITLE
Security: enforce org-slug ownership check for all namespaces in OrganizationMiddleware (VULN-001)

### DIFF
--- a/apps/publish_mdm/middleware.py
+++ b/apps/publish_mdm/middleware.py
@@ -90,11 +90,7 @@ class OrganizationMiddleware:
             organizations = Organization.objects.filter(public_signup_enabled=True)
         else:
             organizations = request.organizations
-        if (
-            "publish_mdm" in resolver_match.namespaces
-            and "organization_slug" in resolver_match.captured_kwargs
-            and organizations is not None
-        ):
+        if "organization_slug" in resolver_match.captured_kwargs and organizations is not None:
             organization_slug = resolver_match.captured_kwargs["organization_slug"]
             organization = get_object_or_404(organizations, slug=organization_slug)
             logger.debug(


### PR DESCRIPTION
Fixes #111.

## Summary

Replaces the `"publish_mdm" in resolver_match.namespaces` guard in `OrganizationMiddleware` with `"organization_slug" in resolver_match.captured_kwargs`. Any view that receives the `organization_slug` URL kwarg — regardless of app namespace — now has the ownership check enforced.

## Diff (apps/publish_mdm/middleware.py)

```diff
 if (
-    "publish_mdm" in resolver_match.namespaces
-    and "organization_slug" in resolver_match.captured_kwargs
+    "organization_slug" in resolver_match.captured_kwargs
     and organizations is not None
 ):
```

## Notes

- No current view was actually vulnerable to this, since `firmware_snapshot` is the only view outside of the `publish_mdm` namespace and it doesn't accept an `organization_slug`; however, making this change now will "future proof" this middleware for URLs in other modules.