### PR TITLE
ci: Add cross-repo deployment workflow dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, ci-dispatch-14-staging-test]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
@@ -49,3 +49,28 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Compute deploy payload
+        id: deploy_payload
+        run: |
+          echo "image_tag=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "environment=production" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=staging" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Dispatch deploy workflow
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: "caktus",
+              repo: "app.publishmdm.com",
+              workflow_id: ".github/workflows/deploy.yml",
+              ref: "14-staging",
+              inputs: {
+                image_tag: "${{ steps.deploy_payload.outputs.image_tag }}",
+                environment: "${{ steps.deploy_payload.outputs.environment }}",
+              },
+            });

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, ci-dispatch-14-staging-test]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
@@ -72,7 +72,7 @@ jobs:
               owner: "caktus",
               repo: "app.publishmdm.com",
               workflow_id: ".github/workflows/deploy.yml",
-              ref: "main",
+              ref: "14-staging",
               inputs: {
                 image_tag: "${{ steps.deploy_payload.outputs.image_tag }}",
                 environment: "${{ steps.deploy_payload.outputs.environment }}",

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,13 +36,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY_WITH_PATH }}/publish-mdm
           # Generate Docker tags based on the following events/attributes
+          # https://github.com/docker/metadata-action?tab=readme-ov-file#priority-attribute
           tags: |
-            type=ref,event=branch
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}.{{hotfix}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=sha
+            type=ref,event=branch,priority=50
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build and push Docker image
@@ -57,11 +55,7 @@ jobs:
       - name: Compute deploy payload
         id: deploy_payload
         run: |
-          image_tag="$(printf '%s\n' '${{ steps.meta.outputs.tags }}' | sed 's/.*://' | grep '^sha-' | head -n 1)"
-          if [[ -z "$image_tag" ]]; then
-            echo "Failed to find sha- image tag in docker/metadata-action output" >&2
-            exit 1
-          fi
+          image_tag="${{ steps.meta.outputs.version }}"
           echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             echo "environment=production" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,12 +43,14 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Compute deploy payload
         id: deploy_payload
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,7 +56,12 @@ jobs:
       - name: Compute deploy payload
         id: deploy_payload
         run: |
-          echo "image_tag=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          image_tag="$(printf '%s\n' '${{ steps.meta.outputs.tags }}' | sed 's/.*://' | grep '^sha-' | head -n 1)"
+          if [[ -z "$image_tag" ]]; then
+            echo "Failed to find sha- image tag in docker/metadata-action output" >&2
+            exit 1
+          fi
+          echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             echo "environment=production" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, ci-dispatch-14-staging-test]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
@@ -68,7 +68,7 @@ jobs:
               owner: "caktus",
               repo: "app.publishmdm.com",
               workflow_id: ".github/workflows/deploy.yml",
-              ref: "main",
+              ref: "14-staging",
               inputs: {
                 image_tag: "${{ steps.deploy_payload.outputs.image_tag }}",
                 environment: "${{ steps.deploy_payload.outputs.environment }}",

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main, ci-dispatch-14-staging-test]
+    branches: [main]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main, ci-dispatch-14-staging-test]
+    branches: [main]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
@@ -42,6 +42,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
@@ -70,7 +72,7 @@ jobs:
               owner: "caktus",
               repo: "app.publishmdm.com",
               workflow_id: ".github/workflows/deploy.yml",
-              ref: "14-staging",
+              ref: "main",
               inputs: {
                 image_tag: "${{ steps.deploy_payload.outputs.image_tag }}",
                 environment: "${{ steps.deploy_payload.outputs.environment }}",

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main, ci-dispatch-14-staging-test]
+    branches: [main, ci-dispatch-14-staging-test, foobar]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main, ci-dispatch-14-staging-test, foobar]
+    branches: [main, ci-dispatch-14-staging-test]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main, ci-dispatch-14-staging-test, foobar]
+    branches: [main]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
@@ -72,7 +72,7 @@ jobs:
               owner: "caktus",
               repo: "app.publishmdm.com",
               workflow_id: ".github/workflows/deploy.yml",
-              ref: "14-staging",
+              ref: "main",
               inputs: {
                 image_tag: "${{ steps.deploy_payload.outputs.image_tag }}",
                 environment: "${{ steps.deploy_payload.outputs.environment }}",

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main, ci-dispatch-14-staging-test]
+    branches: [main]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
@@ -68,7 +68,7 @@ jobs:
               owner: "caktus",
               repo: "app.publishmdm.com",
               workflow_id: ".github/workflows/deploy.yml",
-              ref: "14-staging",
+              ref: "main",
               inputs: {
                 image_tag: "${{ steps.deploy_payload.outputs.image_tag }}",
                 environment: "${{ steps.deploy_payload.outputs.environment }}",

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, ci-dispatch-14-staging-test]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Overview
Implements automated cross-repository workflow dispatch from publish-mdm to app.publishmdm.com for continuous deployment.

## Changes
- **docker-publish.yml**: After successful image build/push, trigger deploy workflow in app.publishmdm.com with image tag and target environment
- Deployment mode determined by push event type:
  - Branch push (main) → staging environment
  - Semver tag push (v*.*.*) → production environment

## Flow
1. Push to main or semver tag in publish-mdm triggers Docker build/push
2. Image tagged as `sha-<7-char-commit-hash>` and pushed to ghcr.io/caktus/publish-mdm
3. Docker build workflow dispatches app.publishmdm.com deploy workflow with image tag
4. App deploy workflow runs Ansible playbook to roll image out to target environment

## Prerequisites
- `DEPLOY_REPO_TOKEN` secret configured in publish-mdm (fine-grained PAT with Actions:write on app.publishmdm.com)
- Deploy secrets configured in app.publishmdm.com
- app.publishmdm.com deploy workflow deployed to main branch

## Testing
Tested end-to-end on branch ci-dispatch-14-staging-test:
- Docker image build completed successfully
- Cross-repo workflow dispatch triggered
- App deployment to staging completed
- Staging pods rolled over to new image tag

## Ready for Review