### PR TITLE
ci: Add PR guardrails

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: docker-publish
 
 on:
   push:

--- a/.github/workflows/main-pr-check.yaml
+++ b/.github/workflows/main-pr-check.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main # Only triggers for PRs where the destination is 'main'
-      - main-pr-guardrail # FIXME: Remove before merging to main
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/main-pr-check.yaml
+++ b/.github/workflows/main-pr-check.yaml
@@ -1,0 +1,49 @@
+name: "Main Branch PR Guardrail"
+
+on:
+  pull_request:
+    branches:
+      - main # Only triggers for PRs where the destination is 'main'
+      - main-pr-guardrail # FIXME: Remove before merging to main
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce-quality:
+    name: "Check Author & Format"
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Block Non-Human Authors (Copilot, etc.)
+      - name: "Verify Human Author"
+        run: |
+          set -euo pipefail
+
+          AUTHOR_TYPE="${{ github.event.pull_request.user.type }}"
+          AUTHOR_NAME="${{ github.event.pull_request.user.login }}"
+
+          echo "Checking PR author: $AUTHOR_NAME"
+
+          if [[ "$AUTHOR_TYPE" != "User" ]]; then
+            echo "::error::PRs targeting 'main' must be authored by a human account. (Detected: $AUTHOR_TYPE)"
+            exit 1
+          fi
+
+      # 2. Lint PR Title (Conventional Commits)
+      - name: "Lint PR Title"
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Standard types that usually trigger CI/CD
+          types: |
+            feat
+            fix
+            chore
+            ci
+            docs
+            perf
+            refactor
+          requireScope: false

--- a/.github/workflows/main-pr-check.yaml
+++ b/.github/workflows/main-pr-check.yaml
@@ -1,4 +1,4 @@
-name: "Main Branch PR Guardrail"
+name: "main-pr-check"
 
 on:
   pull_request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,25 @@ Key hooks that touch generated/edited files:
   reading template diffs or the changes will show as conflicts.
 - `prettier` reformats YAML, CSS, JS, and Markdown.
 
+## Main Branch PR Guardrails
+
+PRs targeting `main` are validated by `.github/workflows/main-pr-check.yaml`, which
+enforces two checks:
+
+1. **Author must be human** — blocks automation accounts (e.g., Copilot, bots) from
+   directly merging changes to `main`.
+2. **PR title follows Conventional Commits** — requires one of: `feat`, `fix`, `chore`,
+   `ci`, `docs`, `perf`, `refactor` (scope is optional).
+
+**Accepted PR titles:**
+
+```
+feat: add organization policy import
+fix: prevent duplicate form template slugs
+docs: clarify local setup prerequisites
+ci: upgrade GitHub Actions runner versions
+```
+
 ## Browser Testing (playwright-cli)
 
 Skills are installed at `.claude/skills/playwright-cli/SKILL.md` — consult them for usage.

--- a/docs/src/contributing.rst
+++ b/docs/src/contributing.rst
@@ -8,6 +8,27 @@ up-to-date information about contributing to this project.
 Setup
 -----
 
+Pull Request Guardrails
+-----------------------
+
+PRs that target ``main`` are validated by the GitHub Actions workflow
+``.github/workflows/main-pr-check.yaml``.
+
+The guardrail currently enforces two checks:
+
+1. PR author must be a human account (GitHub ``User`` type).
+2. PR title must follow Conventional Commit style using one of these types:
+   ``feat``, ``fix``, ``chore``, ``ci``, ``docs``, ``perf``, or ``refactor``.
+
+Examples of accepted PR titles:
+
+* ``feat: add organization policy import``
+* ``fix: prevent duplicate form template slugs``
+* ``docs: clarify local setup prerequisites``
+
+If the check fails, update the PR title or confirm the PR was opened from a
+human account and re-run checks.
+
 Documentation
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR ensures future PRs have human authors and include a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) prefix in the PR name:

<img width="678" height="145" alt="Screenshot 2026-04-09 at 10 03 01 AM" src="https://github.com/user-attachments/assets/70bf42ae-1ff6-4a5d-8960-7180f33f1aeb" />

<img width="1161" height="310" alt="Screenshot 2026-04-09 at 10 03 28 AM" src="https://github.com/user-attachments/assets/623fe32a-7990-43bd-ba9c-4dc0ec5ac72c" />
