### PR TITLE
perf: Route all sync/push actions through Dagster to prevent request hangs.

### DIFF
--- a/apps/mdm/admin.py
+++ b/apps/mdm/admin.py
@@ -20,6 +20,7 @@ from requests.exceptions import RequestException
 
 from apps.mdm.forms import DeviceConfirmImportForm, DeviceImportForm
 from apps.publish_mdm.http import HttpRequest
+from config.dagster import trigger_dagster_job
 
 from .import_export import DeviceResource
 from .mdms import get_active_mdm_instance
@@ -74,28 +75,31 @@ class PolicyAdmin(admin.ModelAdmin):
                 )
             if change:
                 # Update the policies for all related Devices that have a child
-                # policy (device-specific policy)
-                devices = Device.objects.filter(
+                # policy (device-specific policy) asynchronously via Dagster so
+                # the admin save does not block.
+                child_devices = Device.objects.filter(
                     fleet__policy=policy,
                     raw_mdm_device__policyName__endswith=models.F("device_id"),
                 )
-                logger.debug("Updating child policies", count=len(devices))
-                for device in devices:
+                device_pks = list(child_devices.values_list("pk", flat=True))
+                if device_pks:
+                    run_config = {
+                        "ops": {"push_mdm_device_config": {"config": {"device_pks": device_pks}}}
+                    }
                     try:
-                        active_mdm.push_device_config(device)
-                    except (GoogleAPIClientError, RequestException) as e:
+                        trigger_dagster_job(job_name="mdm_job", run_config=run_config)
+                    except Exception as e:
                         logger.debug(
-                            f"Unable to update the policy for {device} in {active_mdm}",
-                            device=device,
+                            "Failed to trigger Dagster mdm_job for child policies",
                             policy=policy,
                             exc_info=True,
                         )
                         messages.warning(
                             request,
                             mark_safe(
-                                f"Could not update the policy for {device} in "
-                                f"{active_mdm} due to the following error:"
-                                f"<br><code>{getattr(e, 'api_error', e)}</code>"
+                                "Could not queue device policy updates due to "
+                                "the following error:"
+                                f"<br><code>{e}</code>"
                             ),
                         )
 

--- a/apps/mdm/import_export.py
+++ b/apps/mdm/import_export.py
@@ -3,7 +3,7 @@ import tablib
 from import_export.resources import ModelResource
 from import_export.results import Result
 
-from config.dagster import dagster_enabled, trigger_dagster_job
+from config.dagster import trigger_dagster_job
 
 from .models import Device, PushMethodChoices
 
@@ -19,33 +19,8 @@ class DeviceResource(ModelResource):
         clean_model_instances = True
         skip_unchanged = True
 
-    def save_instance(self, instance, is_create, row, **kwargs):
-        """Exact copy of the ModelResource.save_instance except it passes a
-        is_dry_run arg to do_instance_save.
-        """
-        self.before_save_instance(instance, row, **kwargs)
-        if self._meta.use_bulk:
-            if is_create:
-                self.create_instances.append(instance)
-            else:
-                self.update_instances.append(instance)
-        else:
-            if not self._is_using_transactions(kwargs) and self._is_dry_run(kwargs):
-                # we don't have transactions and we want to do a dry_run
-                pass
-            else:
-                self.do_instance_save(instance, is_create, self._is_dry_run(kwargs))
-        self.after_save_instance(instance, row, **kwargs)
-
-    def do_instance_save(self, instance: Device, is_create: bool, is_dry_run: bool = False):
-        """Save the instance to the database, optionally pushing to MDM."""
-        push_to_mdm = not is_dry_run and not dagster_enabled()
-        instance.save(push_to_mdm=push_to_mdm)
-
     def after_import(self, dataset: tablib.Dataset, result: Result, dry_run: bool = True, **kwargs):
         super().after_import(dataset, result, **kwargs)
-        if not dagster_enabled():
-            return
         if dry_run:
             logger.debug("Dry run mode, skipping post-import actions")
             return

--- a/apps/mdm/views.py
+++ b/apps/mdm/views.py
@@ -149,7 +149,7 @@ def _get_policy_variables(policy):
     ).select_related("fleet")
 
 
-def _push_policy_to_mdm(policy):
+def _push_policy_to_mdm(policy, request):
     """Push a policy and any device-specific child policies to the MDM.
 
     Errors are logged but not raised so they don't interrupt the view response.
@@ -163,6 +163,10 @@ def _push_policy_to_mdm(policy):
     offloaded to Dagster so they don't block the view.
     """
     active_mdm = get_active_mdm_instance(organization=policy.organization)
+    warning = (
+        "Your policy has been saved, but we encountered an issue syncing it to your devices. "
+        "Please try saving again, or contact support if the problem continues."
+    )
     if not active_mdm:
         logger.warning(
             "Skipping policy push: MDM is not configured. "
@@ -170,6 +174,7 @@ def _push_policy_to_mdm(policy):
             active_mdm_name=settings.ACTIVE_MDM["name"],
             policy=policy,
         )
+        messages.warning(request, warning)
         return
     try:
         active_mdm.create_or_update_policy(policy)
@@ -191,6 +196,7 @@ def _push_policy_to_mdm(policy):
             policy=policy,
             exc_info=True,
         )
+        messages.warning(request, warning)
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +245,7 @@ def policy_add(request, organization_slug):
                 install_type="FORCE_INSTALLED",
                 order=0,
             )
-            _push_policy_to_mdm(policy)
+            _push_policy_to_mdm(policy, request)
             messages.success(request, f"Policy '{policy.name}' created.")
             return redirect("mdm:policy-edit", organization_slug, policy.pk)
     else:
@@ -313,8 +319,8 @@ def policy_edit(request, organization_slug, policy_id):
                 var.save()
             for var in var_formset.deleted_objects:
                 var.delete()
-            _push_policy_to_mdm(policy)
             messages.success(request, "Policy saved.")
+            _push_policy_to_mdm(policy, request)
             return redirect("mdm:policy-edit", organization_slug, policy.pk)
     else:
         form = PolicyEditForm(instance=policy)
@@ -362,7 +368,7 @@ def policy_save_managed_config(request, organization_slug, policy_id, app_id):
         app.save(update_fields=["managed_configuration"])
         saved = True
     if saved:
-        _push_policy_to_mdm(policy)
+        _push_policy_to_mdm(policy, request)
     return render(
         request,
         "mdm/partials/policy_managed_config_form.html",

--- a/apps/mdm/views.py
+++ b/apps/mdm/views.py
@@ -15,6 +15,7 @@ from django.views.decorators.http import require_POST
 
 from apps.publish_mdm.models import AndroidEnterpriseAccount
 from apps.publish_mdm.nav import Breadcrumbs
+from config.dagster import trigger_dagster_job
 
 from .forms import (
     FirmwareSnapshotForm,
@@ -156,6 +157,10 @@ def _push_policy_to_mdm(policy):
     (fleet{id}_{device_id}) that must be updated independently of the base policy.
     We always attempt to push device-specific policies even if the base policy
     update fails, because the device may be on the device-specific policy only.
+
+    The base policy push (single API call) is always synchronous.  The
+    per-device child-policy pushes (one call per enrolled device) are
+    offloaded to Dagster so they don't block the view.
     """
     active_mdm = get_active_mdm_instance(organization=policy.organization)
     if not active_mdm:
@@ -170,14 +175,22 @@ def _push_policy_to_mdm(policy):
         active_mdm.create_or_update_policy(policy)
     except Exception:
         logger.error("Failed to push base policy to MDM", policy=policy, exc_info=True)
-    for device in Device.objects.filter(
+    child_devices = Device.objects.filter(
         fleet__policy=policy,
         raw_mdm_device__policyName__endswith=F("device_id"),
-    ).select_related("fleet__policy"):
-        try:
-            active_mdm.push_device_config(device)
-        except Exception:
-            logger.error("Failed to push device config to MDM", device=device, exc_info=True)
+    )
+    device_pks = list(child_devices.values_list("pk", flat=True))
+    if not device_pks:
+        return
+    run_config = {"ops": {"push_mdm_device_config": {"config": {"device_pks": device_pks}}}}
+    try:
+        trigger_dagster_job(job_name="mdm_job", run_config=run_config)
+    except Exception:
+        logger.error(
+            "Failed to trigger Dagster mdm_job for child policies",
+            policy=policy,
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/publish_mdm/import_export.py
+++ b/apps/publish_mdm/import_export.py
@@ -8,8 +8,8 @@ from django.db.models import Prefetch
 from import_export import fields, resources, widgets
 from import_export.results import Result
 
-from apps.mdm.mdms import get_active_mdm_instance
 from apps.mdm.models import Device
+from config.dagster import trigger_dagster_job
 
 from .models import AppUser, AppUserFormTemplate, AppUserTemplateVariable
 
@@ -329,6 +329,7 @@ class DeviceResource(resources.ModelResource):
 
     def after_import(self, dataset: tablib.Dataset, result: Result, dry_run: bool = True, **kwargs):
         """After a confirmed import, push updated device policies to the MDM.
+        The push is done asynchronously via Dagster.
 
         Only runs on the real import (not the dry-run preview), and only for
         rows that were actually new or updated.  Errors are logged but never
@@ -337,21 +338,15 @@ class DeviceResource(resources.ModelResource):
         super().after_import(dataset, result, **kwargs)
         if dry_run:
             return
-        active_mdm = get_active_mdm_instance(organization=self.organization)
-        if not active_mdm:
-            return
         device_pks = [row.object_id for row in result if row.is_new() or row.is_update()]
         if not device_pks:
             return
-        devices = Device.objects.filter(pk__in=device_pks).select_related(
-            "fleet__policy", "fleet__project"
-        )
-        for device in devices:
-            try:
-                active_mdm.push_device_config(device)
-            except Exception:
-                logger.error(
-                    "Failed to push device config after CSV import",
-                    device=device,
-                    exc_info=True,
-                )
+        run_config = {"ops": {"push_mdm_device_config": {"config": {"device_pks": device_pks}}}}
+        try:
+            trigger_dagster_job(job_name="mdm_job", run_config=run_config)
+        except Exception:
+            logger.error(
+                "Failed to trigger Dagster job after CSV import",
+                device_pks=device_pks,
+                exc_info=True,
+            )

--- a/apps/publish_mdm/views.py
+++ b/apps/publish_mdm/views.py
@@ -877,7 +877,7 @@ def devices_list(request: HttpRequest, organization_slug):
         }
         try:
             trigger_dagster_job(job_name="sync_fleets_job", run_config=run_config)
-        except Exception as e:
+        except Exception:
             logger.error(
                 "Failed to trigger Dagster sync_fleets_job",
                 organization=request.organization,
@@ -886,10 +886,8 @@ def devices_list(request: HttpRequest, organization_slug):
             devices_list_messages.append(
                 messages.Message(
                     messages.ERROR,
-                    mark_safe(
-                        "Unable to queue syncing due to the following error:"
-                        f'<pre class="block text-xs mt-2">{e}</pre>'
-                    ),
+                    "We encountered an issue synchronizing your device list. "
+                    "Please try again, or contact support if the problem continues.",
                 )
             )
         else:

--- a/apps/publish_mdm/views.py
+++ b/apps/publish_mdm/views.py
@@ -40,6 +40,7 @@ from requests.exceptions import RequestException
 from apps.mdm.mdms import AndroidEnterprise, get_active_mdm_instance
 from apps.mdm.models import Device, FirmwareSnapshot, Fleet, Policy
 from apps.tailscale.models import Device as TailscaleDevice
+from config.dagster import trigger_dagster_job
 
 from .etl.load import (
     create_project,
@@ -867,45 +868,36 @@ def devices_list(request: HttpRequest, organization_slug):
 
     if "sync" in request.POST:
         # Sync devices from the MDM
-        if active_mdm := get_active_mdm_instance(organization=request.organization):
-            fleets = request.organization.fleets.all()
-            logger.info(
-                "Syncing MDM devices from the Devices list page",
+        run_config = {
+            "ops": {
+                "sync_and_push_mdm_devices": {
+                    "config": {"organization_pk": request.organization.pk}
+                }
+            }
+        }
+        try:
+            trigger_dagster_job(job_name="sync_fleets_job", run_config=run_config)
+        except Exception as e:
+            logger.error(
+                "Failed to trigger Dagster sync_fleets_job",
                 organization=request.organization,
-                fleets=list(fleets),
+                exc_info=True,
             )
-            synced = 0
-            for fleet in fleets:
-                try:
-                    active_mdm.sync_fleet(fleet, push_config=True)
-                except (GoogleAPIClientError, RequestException) as e:
-                    logger.debug(
-                        "Unable to sync fleet",
-                        fleet=fleet,
-                        organization=request.organization,
-                        exc_info=True,
-                    )
-                    devices_list_messages.append(
-                        messages.Message(
-                            messages.ERROR,
-                            mark_safe(
-                                f"The following error occurred while syncing devices in the {fleet.name} fleet:"
-                                f'<code class="block text-xs mt-2">{getattr(e, "api_error", e)}</code>'
-                            ),
-                        ),
-                    )
-                else:
-                    synced += 1
-            if synced:
-                devices_list_messages.append(
-                    messages.Message(
-                        messages.SUCCESS,
-                        "Successfully synced devices from MDM. The devices list has been updated.",
-                    )
+            devices_list_messages.append(
+                messages.Message(
+                    messages.ERROR,
+                    mark_safe(
+                        "Unable to queue syncing due to the following error:"
+                        f'<pre class="block text-xs mt-2">{e}</pre>'
+                    ),
                 )
+            )
         else:
             devices_list_messages.append(
-                messages.Message(messages.ERROR, "Unable to sync. Please try again later.")
+                messages.Message(
+                    messages.SUCCESS,
+                    "Sync queued — devices will update shortly.",
+                )
             )
 
     devices = (
@@ -1052,15 +1044,15 @@ def device_update_app_user(request: HttpRequest, organization_slug, device_pk):
     form = DeviceAppUserForm(request.POST, instance=device)
     if form.is_valid():
         form.save()
-        if active_mdm := get_active_mdm_instance(organization=request.organization):
-            try:
-                active_mdm.push_device_config(device)
-            except Exception:
-                logger.error(
-                    "Failed to push device config after app_user update",
-                    device=device,
-                    exc_info=True,
-                )
+        run_config = {"ops": {"push_mdm_device_config": {"config": {"device_pks": [device.pk]}}}}
+        try:
+            trigger_dagster_job(job_name="mdm_job", run_config=run_config)
+        except Exception:
+            logger.error(
+                "Failed to trigger Dagster mdm_job after app_user update",
+                device=device,
+                exc_info=True,
+            )
 
     return render(
         request,

--- a/config/dagster.py
+++ b/config/dagster.py
@@ -7,6 +7,10 @@ from django.conf import settings
 logger = structlog.get_logger(__name__)
 
 
+class DagsterNotEnabledError(Exception):
+    """Raised when Dagster is not enabled (DAGSTER_URL is not configured)."""
+
+
 def dagster_enabled() -> bool:
     """Check if Dagster is enabled in the settings."""
     return bool(settings.DAGSTER_URL)
@@ -31,8 +35,7 @@ def trigger_dagster_job(job_name: str, run_config: dict) -> str:
         new_run_id: The ID of the newly created run.
     """
     if not dagster_enabled():
-        logger.warning("Dagster is not enabled, skipping job trigger")
-        return ""
+        raise DagsterNotEnabledError("Dagster is not enabled; set DAGSTER_URL to enable it.")
     config = parse_dagster_url(settings.DAGSTER_URL)
     client = DagsterGraphQLClient(
         hostname=config["hostname"],

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -14,3 +14,5 @@ STORAGES["default"] = {"BACKEND": "django.core.files.storage.FileSystemStorage"}
 ENVIRONMENT = "test"
 
 ANDROID_ENTERPRISE_CALLBACK_DOMAIN = ""
+
+DAGSTER_URL = ""

--- a/dagster_publish_mdm/assets/mdm_devices.py
+++ b/dagster_publish_mdm/assets/mdm_devices.py
@@ -11,6 +11,26 @@ from apps.mdm.models import Device  # noqa: E402
 from apps.publish_mdm.models import Organization  # noqa: E402
 
 
+class SyncFleetsConfig(dg.Config):
+    organization_pk: int
+
+
+@dg.asset(
+    description="Sync specific MDM fleet devices and push device configurations",
+    group_name="mdm_assets",
+)
+def sync_and_push_mdm_devices(context: dg.AssetExecutionContext, config: SyncFleetsConfig):
+    """Sync an organization's fleets from the MDM and push device configurations."""
+    organization = Organization.objects.get(pk=config.organization_pk)
+    active_mdm = get_active_mdm_instance(organization=organization)
+    if not active_mdm:
+        context.log.warning(f"MDM not configured for organization {organization}")
+        return
+    for fleet in organization.fleets.all():
+        active_mdm.sync_fleet(fleet, push_config=True)
+        context.log.info(f"Synced fleet {fleet.name} (pk={fleet.pk})")
+
+
 @dg.asset(description="Get a list of devices from the MDM", group_name="mdm_assets")
 def mdm_device_snapshot():
     if settings.ACTIVE_MDM["name"] == "Android Enterprise":

--- a/dagster_publish_mdm/definitions.py
+++ b/dagster_publish_mdm/definitions.py
@@ -18,6 +18,7 @@ mdm_schedule = dg.ScheduleDefinition(
     default_status=dg.DefaultScheduleStatus.RUNNING,
 )
 mdm_job = dg.define_asset_job(name="mdm_job", selection="push_mdm_device_config")
+sync_fleets_job = dg.define_asset_job(name="sync_fleets_job", selection="sync_and_push_mdm_devices")
 
 tailscale_device_deletion_schedule = dg.ScheduleDefinition(
     name="tailscale_device_deletion_schedule",
@@ -37,5 +38,5 @@ defs = dg.Definitions(
         ),
     },
     schedules=[tailscale_schedule, mdm_schedule, tailscale_device_deletion_schedule],
-    jobs=[mdm_job],
+    jobs=[mdm_job, sync_fleets_job],
 )

--- a/docs/src/local-development/setup.rst
+++ b/docs/src/local-development/setup.rst
@@ -55,7 +55,7 @@ rather use Docker, see :doc:`../running/docker-compose`.
     # endpoint at /mdm/api/amapi/notifications/. If you enable notifications and
     # this is not set, all requests to the endpoint will be rejected.
     # You can generate it with `pwgen -s 32 1`
-    # ANDROID_ENTERPRISE_PUBSUB_TOKEN=
+    export ANDROID_ENTERPRISE_PUBSUB_TOKEN=
     # Optional domain (no scheme, no trailing slash, e.g. "myapp.example.com") used to build
     # the Android Enterprise enrollment callback URL over HTTPS. When set, it replaces the host
     # derived from the incoming request, which is useful for local development where the request
@@ -82,7 +82,7 @@ See :doc:`the tutorial <../running/tutorial>` for more details on the Google and
 
     python manage.py migrate
 
-5. Run the development server.
+5. Run the development server and :doc:`./dagster`.
 
 .. code-block:: bash
 
@@ -90,6 +90,8 @@ See :doc:`the tutorial <../running/tutorial>` for more details on the Google and
     npm run dev
     # in another terminal
     python manage.py runserver
+    # in another terminal
+    dagster dev
 
 6. Set up sample data. Log in with Google first so that your user is added to the sample Organization that will be created.
 

--- a/docs/src/local-development/setup.rst
+++ b/docs/src/local-development/setup.rst
@@ -35,6 +35,9 @@ rather use Docker, see :doc:`../running/docker-compose`.
     export PGDATABASE=publish_mdm
     export DATABASE_URL=postgresql://$PGUSER@$PGHOST:$PGPORT/$PGDATABASE
 
+    # dagster:
+    export DAGSTER_URL=http://localhost:3000
+
     # google oauth for django-allauth
     export GOOGLE_CLIENT_ID=
     export GOOGLE_CLIENT_SECRET=

--- a/tests/dagster/test_dagster_calling.py
+++ b/tests/dagster/test_dagster_calling.py
@@ -64,12 +64,12 @@ def test_trigger_dagster_job(settings, mocker):
 
 
 def test_trigger_dagster_job_not_enabled(settings, mocker):
-    """Test triggering a Dagster job when Dagster is not enabled."""
+    """Test triggering a Dagster job when Dagster is not enabled raises DagsterNotEnabledError."""
     settings.DAGSTER_URL = None
     mock_client = mocker.patch("config.dagster.DagsterGraphQLClient")
-    run_id = dagster.trigger_dagster_job("job_name", {"key": "value"})
-    assert run_id == "", "Run ID should be empty when Dagster is not enabled"
-    mock_client.assert_not_called()  # Ensure no client was created
+    with pytest.raises(dagster.DagsterNotEnabledError):
+        dagster.trigger_dagster_job("job_name", {"key": "value"})
+    mock_client.assert_not_called()
 
 
 def test_trigger_dagster_job_error(settings, mocker):

--- a/tests/dagster_publish_mdm/test_sync_and_push_mdm_devices.py
+++ b/tests/dagster_publish_mdm/test_sync_and_push_mdm_devices.py
@@ -1,0 +1,51 @@
+import dagster as dg
+import pytest
+
+from apps.mdm.mdms import get_active_mdm_class
+from dagster_publish_mdm.assets.mdm_devices import SyncFleetsConfig, sync_and_push_mdm_devices
+from tests.mdm import TestAllMDMs
+from tests.mdm.factories import FleetFactory
+
+
+@pytest.mark.django_db
+class TestSyncAndPushMDMDevices(TestAllMDMs):
+    """Test suite for syncing MDM fleets and pushing device configurations."""
+
+    def test_sync_fleet_called_for_each_fleet(self, mocker, set_mdm_env_vars, organization):
+        """sync_fleet() is called for each fleet in the organization, with push_config=True."""
+        mock_sync = mocker.patch.object(get_active_mdm_class(), "sync_fleet")
+        fleet1, fleet2 = FleetFactory.create_batch(2, organization=organization)
+
+        sync_and_push_mdm_devices(
+            context=dg.build_asset_context(),
+            config=SyncFleetsConfig(organization_pk=organization.pk),
+        )
+
+        assert mock_sync.call_count == 2
+        mock_sync.assert_any_call(fleet1, push_config=True)
+        mock_sync.assert_any_call(fleet2, push_config=True)
+
+    def test_no_matching_fleets(self, mocker, set_mdm_env_vars, organization):
+        """When the organization has no fleets, sync_fleet() is never called."""
+        mock_sync = mocker.patch.object(get_active_mdm_class(), "sync_fleet")
+        # Create some fleets in other organizations
+        FleetFactory.create_batch(2)
+
+        sync_and_push_mdm_devices(
+            context=dg.build_asset_context(),
+            config=SyncFleetsConfig(organization_pk=organization.pk),
+        )
+
+        mock_sync.assert_not_called()
+
+    def test_no_active_mdm(self, mocker):
+        """When the active MDM is not configured, sync_fleet() is never called."""
+        mock_sync = mocker.patch.object(get_active_mdm_class(), "sync_fleet")
+        fleet = FleetFactory()
+
+        sync_and_push_mdm_devices(
+            context=dg.build_asset_context(),
+            config=SyncFleetsConfig(organization_pk=fleet.organization.pk),
+        )
+
+        mock_sync.assert_not_called()

--- a/tests/mdm/test_admin.py
+++ b/tests/mdm/test_admin.py
@@ -64,9 +64,7 @@ class TestDeviceAdmin(TestAdmin):
             assert Device.objects.get(id=id).app_user_name == app_user_name
         return response
 
-    def test_confirm_import_with_no_errors(
-        self, client, user, dataset, organization, set_mdm_env_vars
-    ):
+    def test_confirm_import_with_no_errors(self, client, user, dataset, mocker, organization):
         """Happy path: confirming an import and no errors occur when saving changes."""
         # Change the app_user_name on the first 2 devices
         expected_app_user_names = {}
@@ -86,6 +84,7 @@ class TestDeviceAdmin(TestAdmin):
                 new_device.device_id,
             ]
         )
+        mocker.patch("apps.mdm.import_export.trigger_dagster_job")
         response = self.check_import(client, dataset, expected_app_user_names)
         # We should now have 4 Devices: 3 existing devices + 1 new device
         assert Device.objects.count() == 4
@@ -94,9 +93,7 @@ class TestDeviceAdmin(TestAdmin):
             in response.content.decode()
         )
 
-    def test_confirm_import_with_errors(
-        self, client, user, dataset, mocker, set_mdm_env_vars, settings
-    ):
+    def test_confirm_import_with_errors(self, client, user, dataset, mocker):
         """Ensure error messages are shown for errors that occur during the
         confirmation step of an import, and any devices that were added/updated
         and did not have errors are saved in the database.
@@ -105,15 +102,9 @@ class TestDeviceAdmin(TestAdmin):
         expected_app_user_names = {}
         for index, row in enumerate(dataset[:2]):
             row = list(row)
-            before = row[3]
             row[3] += "_edited"
             dataset[index] = row
-            if index:
-                expected_app_user_names[row[0]] = row[3]
-            else:
-                # We will fake an exception within the save() for the first row, so it
-                # won't actually get updated in the database
-                expected_app_user_names[row[0]] = before
+            expected_app_user_names[row[0]] = row[3]
         # Add two new rows, but one will have a validation error (a duplicate device_id)
         for index, new_device in enumerate(DeviceFactory.build_batch(2)):
             row = [
@@ -124,22 +115,15 @@ class TestDeviceAdmin(TestAdmin):
                 new_device.device_id if index else dataset[0][-1],
             ]
             dataset.append(row)
-        MDM = get_active_mdm_class()
-        mocker.patch.object(
-            MDM,
-            "push_device_config",
-            side_effect=[Exception("MDM API error")] + [None] * 4,
-        )
+        mocker.patch("apps.mdm.import_export.trigger_dagster_job")
         response = self.check_import(client, dataset, expected_app_user_names)
         # We should now have 4 Devices: 3 existing devices + 1 new device
         assert Device.objects.count() == 4
         response_content = response.content.decode()
         assert (
-            "Import finished: 1 new, 1 updated, 0 deleted and 1 skipped devices."
+            "Import finished: 1 new, 2 updated, 0 deleted and 1 skipped devices."
             in response_content
         )
-        # An error message for the exception within save()
-        assert "Row 1: Exception('MDM API error')" in response_content
         # An error message for the validation error on one of the new Devices
         assert (
             "Row 4, Column 'device_id': Device with this Device ID already exists."
@@ -500,7 +484,7 @@ class TestPolicyAdmin(TestAdmin):
         organization,
     ):
         """Ensures the create_or_update_policy() method is called when editing a Policy
-        and the active MDM has the method.
+        and child-device config pushes are queued via Dagster.
         """
         policy = PolicyFactory(organization=organization)
         data = {
@@ -519,12 +503,11 @@ class TestPolicyAdmin(TestAdmin):
         }
         MDM = get_active_mdm_class()
         mdm_has_method = hasattr(MDM, "create_or_update_policy")
+        devices_to_push = []
         if mdm_has_method:
             mock_create_or_update_policy = mocker.patch.object(
                 MDM, "create_or_update_policy", side_effect=mdm_api_error
             )
-            device_api_error = mdm_api_error_class("error")
-            devices_to_push = []
             fleet = FleetFactory(policy=policy)
             for device in DeviceFactory.build_batch(2, fleet=fleet):
                 device.raw_mdm_device = {
@@ -537,16 +520,15 @@ class TestPolicyAdmin(TestAdmin):
                 fleet=fleet,
                 raw_mdm_device={"policyName": f"enterprises/test/policies/{policy.policy_id}"},
             )
-            mock_push_device_config = mocker.patch.object(
-                MDM, "push_device_config", side_effect=[None, device_api_error]
-            )
-        else:
-            mock_push_device_config = mocker.patch.object(MDM, "push_device_config")
+        mock_push_device_config = mocker.patch.object(MDM, "push_device_config")
+        mock_trigger = mocker.patch("apps.mdm.admin.trigger_dagster_job")
+
         response = client.post(
             reverse("admin:mdm_policy_change", args=[policy.id]), data=data, follow=True
         )
 
         assert response.status_code == 200
+        mock_push_device_config.assert_not_called()
         if mdm_has_method:
             mock_create_or_update_policy.assert_called_once()
             if mdm_api_error:
@@ -558,21 +540,14 @@ class TestPolicyAdmin(TestAdmin):
                         f"<br><code>{mdm_api_error}</code>"
                     ),
                 )
-            assert mock_push_device_config.call_count == 2
-            mock_push_device_config.assert_has_calls(
-                [mocker.call(device) for device in devices_to_push],
-                any_order=True,
-            )
-            assertContains(
-                response,
-                (
-                    f"Could not update the policy for {devices_to_push[1]} in "
-                    f"{MDM.name} due to the following error:"
-                    f"<br><code>{device_api_error}</code>"
-                ),
-            )
+            if devices_to_push:
+                mock_trigger.assert_called_once()
+                device_pks = mock_trigger.call_args.kwargs["run_config"]["ops"][
+                    "push_mdm_device_config"
+                ]["config"]["device_pks"]
+                assert set(device_pks) == {d.pk for d in devices_to_push}
         else:
-            mock_push_device_config.assert_not_called()
+            mock_trigger.assert_not_called()
 
     def test_policy_push_happens_after_inline_applications_saved(
         self, user, client, mocker, set_mdm_env_vars, organization
@@ -620,6 +595,117 @@ class TestPolicyAdmin(TestAdmin):
         assert response.status_code == 200
         # The inline application must already be in the DB when the MDM push fires
         assert "com.example.inline" in pushed_package_names
+
+
+class TestPolicyAdminDagster(TestAdmin):
+    """Tests that PolicyAdmin.save_related() uses Dagster for child-device pushes."""
+
+    @pytest.fixture
+    def policy_data_base(self):
+        MDM = get_active_mdm_class()
+        return {
+            "name": "Dagster Test Policy",
+            "policy_id": "dagster_test",
+            "mdm": MDM.name,
+            "odk_collect_package": "org.odk.collect.android",
+            "device_password_quality": "PASSWORD_QUALITY_UNSPECIFIED",
+            "device_password_require_unlock": "REQUIRE_PASSWORD_UNLOCK_UNSPECIFIED",
+            "work_password_quality": "PASSWORD_QUALITY_UNSPECIFIED",
+            "work_password_require_unlock": "REQUIRE_PASSWORD_UNLOCK_UNSPECIFIED",
+            "developer_settings": "DEVELOPER_SETTINGS_DISABLED",
+            "applications-TOTAL_FORMS": "0",
+            "applications-INITIAL_FORMS": "0",
+        }
+
+    @pytest.fixture
+    def policy_with_child_devices(self, organization):
+        policy = PolicyFactory(organization=organization)
+        fleet = FleetFactory(policy=policy)
+        devices = []
+        for device in DeviceFactory.create_batch(2, fleet=fleet):
+            device.raw_mdm_device = {
+                "policyName": f"enterprises/test/policies/fleet{fleet.id}_{device.device_id}"
+            }
+            device.save()
+            devices.append(device)
+        return policy, devices
+
+    def test_dagster_triggered_for_child_devices(
+        self, user, client, mocker, set_mdm_env_vars, policy_with_child_devices
+    ):
+        """save_related() queues per-device config pushes via Dagster mdm_job."""
+        MDM = get_active_mdm_class()
+        policy, devices = policy_with_child_devices
+        mocker.patch.object(MDM, "create_or_update_policy")
+        mock_push = mocker.patch.object(MDM, "push_device_config")
+        mock_trigger = mocker.patch("apps.mdm.admin.trigger_dagster_job")
+        data = {
+            "name": policy.name,
+            "policy_id": policy.policy_id,
+            "mdm": policy.mdm,
+            "odk_collect_package": policy.odk_collect_package,
+            "device_password_quality": policy.device_password_quality,
+            "device_password_require_unlock": policy.device_password_require_unlock,
+            "work_password_quality": policy.work_password_quality,
+            "work_password_require_unlock": policy.work_password_require_unlock,
+            "developer_settings": policy.developer_settings,
+            "applications-TOTAL_FORMS": "0",
+            "applications-INITIAL_FORMS": "0",
+            "organization": policy.organization.id,
+        }
+
+        response = client.post(
+            reverse("admin:mdm_policy_change", args=[policy.id]), data=data, follow=True
+        )
+
+        assert response.status_code == 200
+        mock_push.assert_not_called()
+        mock_trigger.assert_called_once()
+        call_kwargs = mock_trigger.call_args
+        assert call_kwargs.kwargs["job_name"] == "mdm_job"
+        device_pks = call_kwargs.kwargs["run_config"]["ops"]["push_mdm_device_config"]["config"][
+            "device_pks"
+        ]
+        assert set(device_pks) == {d.pk for d in devices}
+
+    def test_dagster_exception_shows_warning(
+        self, user, client, mocker, set_mdm_env_vars, policy_with_child_devices
+    ):
+        """save_related() shows a warning and does not raise when trigger_dagster_job fails."""
+        MDM = get_active_mdm_class()
+        if not hasattr(MDM, "create_or_update_policy"):
+            pytest.skip("MDM does not have create_or_update_policy")
+        policy, _ = policy_with_child_devices
+        mocker.patch.object(MDM, "create_or_update_policy")
+        dagster_error = Exception("Dagster unavailable")
+        mock_trigger = mocker.patch("apps.mdm.admin.trigger_dagster_job", side_effect=dagster_error)
+        data = {
+            "name": policy.name,
+            "policy_id": policy.policy_id,
+            "mdm": policy.mdm,
+            "odk_collect_package": policy.odk_collect_package,
+            "device_password_quality": policy.device_password_quality,
+            "device_password_require_unlock": policy.device_password_require_unlock,
+            "work_password_quality": policy.work_password_quality,
+            "work_password_require_unlock": policy.work_password_require_unlock,
+            "developer_settings": policy.developer_settings,
+            "applications-TOTAL_FORMS": "0",
+            "applications-INITIAL_FORMS": "0",
+            "organization": policy.organization.id,
+        }
+
+        response = client.post(
+            reverse("admin:mdm_policy_change", args=[policy.id]), data=data, follow=True
+        )
+
+        assert response.status_code == 200
+        mock_trigger.assert_called_once()
+        assertContains(
+            response,
+            "Could not queue device policy updates due to "
+            "the following error:"
+            f"<br><code>{dagster_error}</code>",
+        )
 
 
 class TestFleetAdminDeleteConfirmation(TestAdmin):

--- a/tests/mdm/test_import_export.py
+++ b/tests/mdm/test_import_export.py
@@ -20,9 +20,9 @@ class TestDeviceResource(TestAllMDMs):
     )
 
     @pytest.fixture(autouse=True)
-    def disable_dagster(self, settings):
-        """Disable Dagster queuing for these tests."""
-        settings.DAGSTER_URL = None
+    def mock_trigger(self, mocker):
+        """Mock Dagster job triggering — not under test in this class."""
+        return mocker.patch("apps.mdm.import_export.trigger_dagster_job")
 
     @pytest.fixture
     def fleet(self, organization):
@@ -167,12 +167,8 @@ class TestDeviceResource(TestAllMDMs):
         assert isinstance(error_list[0].error, models.Fleet.DoesNotExist)
 
     @pytest.mark.parametrize("dry_run", [True, False])
-    def test_valid_import_dry_run(
-        self, fleet, devices, dataset, mocker, dry_run, set_mdm_env_vars, settings
-    ):
-        """Ensure we only push to the MDM when an import is confirmed and not
-        during the dry run (preview).
-        """
+    def test_valid_import_dry_run(self, fleet, devices, dataset, mocker, dry_run, set_mdm_env_vars):
+        """Ensure Device saves do not push to MDM directly; Dagster handles MDM pushes."""
         # Add one edited device to the import data
         device = devices[0]
         row = list(models.Device.objects.values_list(*dataset.headers).get(id=device.id))
@@ -187,18 +183,15 @@ class TestDeviceResource(TestAllMDMs):
         result = resource.import_data(dataset, dry_run=dry_run)
         # Ensure there are no validation errors
         assert len(result.valid_rows()) == 1
-        # Ensure Device.save is called and push_device_config() is only called
-        # if the import is not a dry run
+        # Device.save is called (in a rolled-back transaction for dry runs)
         mock_device_save.assert_called()
-        if dry_run:
-            mock_push_device_config.assert_not_called()
-        else:
-            mock_push_device_config.assert_called()
+        # push_device_config is never called directly — Dagster handles it
+        mock_push_device_config.assert_not_called()
 
 
 @pytest.mark.django_db
 class TestDeviceResourceAfterImport(TestAllMDMs):
-    """Tests for after_import() behavior when Dagster is enabled."""
+    """Tests for after_import() behavior."""
 
     HEADERS = (
         "id",
@@ -282,26 +275,18 @@ class TestDeviceResourceSaveInstance(TestAllMDMs):
     def fleet(self):
         return FleetFactory()
 
-    @pytest.fixture(autouse=True)
-    def disable_dagster(self, settings):
-        settings.DAGSTER_URL = None
-
-    def test_do_instance_save_dry_run_does_not_push(self, fleet, mocker):
-        """do_instance_save() with is_dry_run=True does not call save(push_to_mdm=True)."""
+    def test_do_instance_save_does_not_push_to_mdm(self, fleet, mocker):
+        """do_instance_save() always saves with push_to_mdm=False; Dagster handles MDM pushes."""
         device = DeviceFactory(fleet=fleet)
         mock_save = mocker.patch.object(device, "save")
         resource = import_export.DeviceResource()
-        resource.do_instance_save(device, is_create=False, is_dry_run=True)
-        mock_save.assert_called_once_with(push_to_mdm=False)
+        resource.do_instance_save(device, is_create=False)
+        mock_save.assert_called_once_with()
 
 
 @pytest.mark.django_db
 class TestDeviceResourceBulkMode(TestAllMDMs):
     """Tests for save_instance() when use_bulk=True."""
-
-    @pytest.fixture(autouse=True)
-    def disable_dagster(self, settings):
-        settings.DAGSTER_URL = None
 
     @pytest.fixture
     def fleet(self):

--- a/tests/mdm/test_views.py
+++ b/tests/mdm/test_views.py
@@ -2,9 +2,10 @@ import base64
 import json
 
 import pytest
+from django.contrib.messages import SUCCESS, WARNING, Message
 from django.urls import reverse, reverse_lazy
 from django.utils.timezone import now
-from pytest_django.asserts import assertContains, assertRedirects
+from pytest_django.asserts import assertContains, assertMessages, assertRedirects
 
 from apps.mdm.mdms import AndroidEnterprise
 from apps.mdm.models import Device, DeviceSnapshot, Policy, PolicyApplication, PolicyVariable
@@ -957,4 +958,15 @@ class TestPushPolicyToMdmDagster(PolicyViewBase):
             "Failed to trigger Dagster mdm_job for child policies" in r.message
             for r in caplog.records
             if r.name == "apps.mdm.views" and r.levelname == "ERROR"
+        )
+        assertMessages(
+            response,
+            [
+                Message(SUCCESS, "Policy saved."),
+                Message(
+                    WARNING,
+                    "Your policy has been saved, but we encountered an issue syncing it to your devices. "
+                    "Please try saving again, or contact support if the problem continues.",
+                ),
+            ],
         )

--- a/tests/mdm/test_views.py
+++ b/tests/mdm/test_views.py
@@ -847,3 +847,114 @@ class TestAmapiNotificationsView(TestAndroidEnterpriseOnly):
         response = self.post(client, body)
         assert response.status_code == 204
         assert DeviceSnapshot.objects.count() == before
+
+
+# ---------------------------------------------------------------------------
+# _push_policy_to_mdm — Dagster integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPushPolicyToMdmDagster(PolicyViewBase):
+    """Tests that _push_policy_to_mdm() uses Dagster for child-device pushes."""
+
+    @pytest.fixture
+    def policy_with_devices(self, organization):
+        policy = PolicyFactory(organization=organization)
+        fleet = FleetFactory(policy=policy)
+        devices = []
+        for device in DeviceFactory.build_batch(2, fleet=fleet):
+            device.raw_mdm_device = {
+                "policyName": f"enterprises/test/policies/fleet{fleet.id}_{device.device_id}"
+            }
+            device.save()
+            devices.append(device)
+        return policy, devices
+
+    @pytest.fixture
+    def url(self, organization, policy_with_devices):
+        policy, _ = policy_with_devices
+        return reverse("mdm:policy-edit", args=[organization.slug, policy.pk])
+
+    def _valid_data(self):
+        return {
+            "name": "Test Policy",
+            "odk_collect_package": "org.odk.collect.android",
+            "odk_collect_device_id_template": "",
+            "device_password_quality": "PASSWORD_QUALITY_UNSPECIFIED",
+            "device_password_min_length": "",
+            "device_password_require_unlock": "REQUIRE_PASSWORD_UNLOCK_UNSPECIFIED",
+            "work_password_quality": "PASSWORD_QUALITY_UNSPECIFIED",
+            "work_password_min_length": "",
+            "work_password_require_unlock": "REQUIRE_PASSWORD_UNLOCK_UNSPECIFIED",
+            "vpn_package_name": "",
+            "kiosk_power_button_actions": "POWER_BUTTON_ACTIONS_UNSPECIFIED",
+            "kiosk_system_error_warnings": "SYSTEM_ERROR_WARNINGS_UNSPECIFIED",
+            "kiosk_system_navigation": "SYSTEM_NAVIGATION_UNSPECIFIED",
+            "kiosk_status_bar": "STATUS_BAR_UNSPECIFIED",
+            "kiosk_device_settings": "DEVICE_SETTINGS_UNSPECIFIED",
+            "developer_settings": "DEVELOPER_SETTINGS_DISABLED",
+            "apps-TOTAL_FORMS": "0",
+            "apps-INITIAL_FORMS": "0",
+            "vars-TOTAL_FORMS": "1",
+            "vars-INITIAL_FORMS": "0",
+            "vars-MIN_NUM_FORMS": "0",
+            "vars-MAX_NUM_FORMS": "1000",
+        }
+
+    def test_dagster_triggered_for_child_devices(
+        self,
+        client,
+        url,
+        user,
+        organization,
+        policy_with_devices,
+        mocker,
+        set_mdm_env_vars,
+    ):
+        """_push_policy_to_mdm() queues child-device config pushes via Dagster mdm_job."""
+        _, devices = policy_with_devices
+        mock_push = mocker.patch("apps.mdm.views.get_active_mdm_instance")
+        mock_trigger = mocker.patch("apps.mdm.views.trigger_dagster_job")
+
+        response = client.post(url, self._valid_data())
+
+        assert response.status_code == 302
+        mock_trigger.assert_called_once()
+        call_kwargs = mock_trigger.call_args
+        assert call_kwargs.kwargs["job_name"] == "mdm_job"
+        device_pks = call_kwargs.kwargs["run_config"]["ops"]["push_mdm_device_config"]["config"][
+            "device_pks"
+        ]
+        assert set(device_pks) == {d.pk for d in devices}
+        mock_push.return_value.push_device_config.assert_not_called()
+
+    def test_dagster_exception_is_swallowed(
+        self,
+        client,
+        url,
+        user,
+        organization,
+        policy_with_devices,
+        mocker,
+        set_mdm_env_vars,
+        caplog,
+    ):
+        """_push_policy_to_mdm() logs and swallows a trigger_dagster_job exception without
+        interrupting the view response.
+        """
+        mocker.patch("apps.mdm.views.get_active_mdm_instance")
+        mock_trigger = mocker.patch(
+            "apps.mdm.views.trigger_dagster_job",
+            side_effect=Exception("Dagster unavailable"),
+        )
+
+        response = client.post(url, self._valid_data())
+
+        assert response.status_code == 302
+        mock_trigger.assert_called_once()
+        assert any(
+            "Failed to trigger Dagster mdm_job for child policies" in r.message
+            for r in caplog.records
+            if r.name == "apps.mdm.views" and r.levelname == "ERROR"
+        )

--- a/tests/publish_mdm/import_export/test_import_export.py
+++ b/tests/publish_mdm/import_export/test_import_export.py
@@ -1,5 +1,3 @@
-from unittest.mock import call
-
 import pytest
 from tablib import Dataset
 
@@ -477,9 +475,7 @@ class TestDeviceResource(TestAllMDMsNoAutouse):
 
     @pytest.mark.parametrize("dry_run", [True, False])
     def test_valid_import_dry_run(self, organization, mocker, dry_run, all_mdms, set_mdm_env_vars):
-        """Ensure we only push to the MDM when an import is confirmed and not
-        during the dry run (preview).
-        """
+        """Ensure push_device_config is never called directly; Dagster handles MDM pushes."""
         devices = DeviceFactory.create_batch(3, fleet__organization=organization)
         csv_data = "device_id,serial_number,app_user_name\n"
         # Update 2 of the 3 devices
@@ -491,16 +487,59 @@ class TestDeviceResource(TestAllMDMsNoAutouse):
 
         MDM = get_active_mdm_class()
         mock_push_device_config = mocker.patch.object(MDM, "push_device_config")
+        mocker.patch("apps.publish_mdm.import_export.trigger_dagster_job")
         result = self.import_data(csv_data, organization, dry_run=dry_run)
 
         # Ensure there are no validation errors
         assert len(result.valid_rows()) == 3
-        # Ensure push_device_config() is only called for the edited devices if
-        # the import is not a dry run
-        if dry_run:
-            mock_push_device_config.assert_not_called()
-        else:
-            assert mock_push_device_config.call_count == 2
-            mock_push_device_config.assert_has_calls(
-                [call(device) for device in devices[1:]], any_order=True
-            )
+        # push_device_config is never called directly — Dagster handles it
+        mock_push_device_config.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestDeviceResourceAfterImport:
+    """Tests for DeviceResource.after_import()."""
+
+    @pytest.fixture
+    def organization(self):
+        return OrganizationFactory()
+
+    def import_data(self, csv_data, organization, dry_run=False):
+        dataset = Dataset().load(csv_data)
+        resource = import_export.DeviceResource(organization)
+        return resource.import_data(
+            dataset, use_transactions=True, rollback_on_validation_errors=True, dry_run=dry_run
+        )
+
+    def test_after_import_with_dagster_triggers_job(self, organization, mocker, set_mdm_env_vars):
+        """after_import() triggers mdm_job for each updated device."""
+        devices = DeviceFactory.create_batch(2, fleet__organization=organization)
+        csv_data = "device_id,serial_number,app_user_name\n"
+        for device in devices:
+            csv_data += f"{device.device_id},{device.serial_number},{device.app_user_name}_edited\n"
+
+        MDM = get_active_mdm_class()
+        mock_push_device_config = mocker.patch.object(MDM, "push_device_config")
+        mock_trigger = mocker.patch("apps.publish_mdm.import_export.trigger_dagster_job")
+
+        self.import_data(csv_data, organization)
+
+        mock_push_device_config.assert_not_called()
+        mock_trigger.assert_called_once()
+        device_pks = mock_trigger.call_args.kwargs["run_config"]["ops"]["push_mdm_device_config"][
+            "config"
+        ]["device_pks"]
+        assert set(device_pks) == {device.pk for device in devices}
+
+    def test_after_import_dry_run_skips_dagster(self, organization, mocker, set_mdm_env_vars):
+        """Dry-run imports do not trigger the Dagster job."""
+        devices = DeviceFactory.create_batch(2, fleet__organization=organization)
+        csv_data = "device_id,serial_number,app_user_name\n"
+        for device in devices:
+            csv_data += f"{device.device_id},{device.serial_number},{device.app_user_name}_edited\n"
+
+        mock_trigger = mocker.patch("apps.publish_mdm.import_export.trigger_dagster_job")
+
+        self.import_data(csv_data, organization, dry_run=True)
+
+        mock_trigger.assert_not_called()

--- a/tests/publish_mdm/import_export/test_views.py
+++ b/tests/publish_mdm/import_export/test_views.py
@@ -14,6 +14,7 @@ from import_export.tmp_storages import MediaStorage
 from pytest_django.asserts import assertContains, assertFormError, assertMessages
 from tablib import Dataset
 
+from apps.mdm.mdms import get_active_mdm_class
 from apps.publish_mdm.forms import (
     ConfirmImportForm,
     ExportForm,
@@ -406,12 +407,11 @@ class TestDeviceImport(ImportTestBase):
     def test_push_device_config_called_after_confirm(
         self, client, url, user, organization, devices, dataset, mocker
     ):
-        """Confirming a CSV import triggers push_device_config for each updated device."""
-        mock_mdm = mocker.MagicMock()
-        mocker.patch(
-            "apps.publish_mdm.import_export.get_active_mdm_instance", return_value=mock_mdm
-        )
-        mock_push = mock_mdm.push_device_config
+        """Confirming a CSV import triggers Dagster mdm_job for updated devices and
+        not the push_device_config method of the currently active MDM.
+        """
+        mock_trigger = mocker.patch("apps.publish_mdm.import_export.trigger_dagster_job")
+        mock_push = mocker.patch.object(get_active_mdm_class(), "push_device_config")
 
         import_format_cls, _, form_format = self.FORMATS["csv"]
         import_file_data = dataset.export("csv")
@@ -428,25 +428,28 @@ class TestDeviceImport(ImportTestBase):
         }
         client.post(url, data=data, follow=True)
 
-        assert mock_push.call_count == len(devices)
-        pushed_pks = {call.args[0].pk for call in mock_push.call_args_list}
-        assert pushed_pks == {d.pk for d in devices}
+        mock_trigger.assert_called_once()
+        mock_push.assert_not_called()
+        device_pks = mock_trigger.call_args.kwargs["run_config"]["ops"]["push_mdm_device_config"][
+            "config"
+        ]["device_pks"]
+        assert set(device_pks) == {d.pk for d in devices}
 
     def test_push_device_config_not_called_on_dry_run(
         self, client, url, user, devices, dataset, mocker
     ):
-        """During the dry-run preview stage, push_device_config is not called."""
-        mock_mdm = mocker.MagicMock()
-        mocker.patch(
-            "apps.publish_mdm.import_export.get_active_mdm_instance", return_value=mock_mdm
-        )
-        mock_push = mock_mdm.push_device_config
+        """During the dry-run preview stage, neither the Dagster mdm_job nor the
+        push_device_config method of the currently active MDM is called.
+        """
+        mock_trigger = mocker.patch("apps.publish_mdm.import_export.trigger_dagster_job")
+        mock_push = mocker.patch.object(get_active_mdm_class(), "push_device_config")
 
         _, io_class, form_format = self.FORMATS["csv"]
         import_file_data = dataset.export("csv")
         data = {"format": form_format, "import_file": io_class(import_file_data)}
         client.post(url, data=data)
 
+        mock_trigger.assert_not_called()
         mock_push.assert_not_called()
 
 

--- a/tests/publish_mdm/test_views.py
+++ b/tests/publish_mdm/test_views.py
@@ -2296,89 +2296,44 @@ class TestDevicesList(ViewTestBase, TestAllMDMsNoAutouse):
             (fleet.id, f"{fleet.name} (10)") for fleet in fleets
         }
 
-    @pytest.mark.parametrize("num_successful_fleets", [0, 1, 2])
-    def test_sync(
-        self,
-        client,
-        url,
-        user,
-        organization,
-        mocker,
-        all_mdms,
-        set_mdm_env_vars,
-        num_successful_fleets,
-        mdm_api_error,
-    ):
-        """Ensure syncing calls sync_fleet for all the fleets in an organization
-        and the updated device list is included in the response.
-        """
+    def test_sync(self, client, url, user, organization, mocker, all_mdms):
+        """The sync button triggers sync_fleets_job with the org's PKs via Dagster."""
         MDM = get_active_mdm_class()
-        mocker.patch.object(MDM, "pull_devices")
-        num_fleets = 2
-        num_devices_before = 3
-        fleets = FleetFactory.create_batch(num_fleets, organization=organization)
-        devices = DeviceFactory.create_batch(num_devices_before, fleet=fleets[0])
-        api_error_fleets = fleets[num_successful_fleets:num_fleets]
-
-        # Mock sync_fleet. It will either add one new Device or raise an API error
-        def side_effect(fleet, push_config):
-            if fleet in api_error_fleets:
-                raise mdm_api_error
-            devices.append(DeviceFactory(fleet=fleet))
-
-        mock_sync_fleet = mocker.patch.object(MDM, "sync_fleet", side_effect=side_effect)
-
-        response = client.post(url, data={"sync": 1})
-
-        # Ensure the expected sync_fleet calls have been made
-        assert mock_sync_fleet.call_count == len(fleets)
-        assert {
-            (call.args[0], call.kwargs["push_config"]) for call in mock_sync_fleet.mock_calls
-        } == {(fleet, True) for fleet in fleets}
-        # Ensure the expected devices list is included in the response
-        table = response.context.get("table")
-        assert isinstance(table, Table)
-        rows = table.as_values()
-        headers = next(rows)
-        device_id_index = headers.index("Device ID")
-        assert {row[device_id_index] for row in rows} == {device.device_id for device in devices}
-        assert len(devices) == (num_devices_before + num_successful_fleets)
-        assertContains(response, table.as_html(response.wsgi_request))
-        for fleet in api_error_fleets:
-            assertContains(
-                response,
-                f"The following error occurred while syncing devices in the {fleet.name} fleet:"
-                f'<code class="block text-xs mt-2">{mdm_api_error}</code>',
-            )
-        success_message = "Successfully synced devices from MDM. The devices list has been updated."
-        if num_successful_fleets:
-            # Ensure a success message is displayed
-            assertContains(response, success_message)
-        else:
-            assertNotContains(response, success_message)
-
-    def test_sync_no_api_credentials(self, client, url, user, organization, mocker, all_mdms):
-        """Ensure syncing is not attempted if the active MDM's API is not configured
-        and a message is shown to the user that syncing failed.
-        """
-        MDM = get_active_mdm_class()
-        mocker.patch.object(MDM, "pull_devices")
         mock_sync_fleet = mocker.patch.object(MDM, "sync_fleet")
-        fleets = FleetFactory.create_batch(3, organization=organization)
-        devices = DeviceFactory.create_batch(3, fleet=fleets[0])
+        mock_trigger = mocker.patch("apps.publish_mdm.views.trigger_dagster_job")
         response = client.post(url, data={"sync": 1})
 
         mock_sync_fleet.assert_not_called()
-        # Ensure the expected devices list is included in the response
-        table = response.context.get("table")
-        assert isinstance(table, Table)
-        rows = table.as_values()
-        headers = next(rows)
-        device_id_index = headers.index("Device ID")
-        assert {row[device_id_index] for row in rows} == {device.device_id for device in devices}
-        assertContains(response, table.as_html(response.wsgi_request))
-        # Ensure an error message is displayed
-        assertContains(response, "Unable to sync. Please try again later.")
+        mock_trigger.assert_called_once()
+        call_kwargs = mock_trigger.call_args
+        assert call_kwargs.kwargs["job_name"] == "sync_fleets_job"
+        assert (
+            organization.pk
+            == call_kwargs.kwargs["run_config"]["ops"]["sync_and_push_mdm_devices"]["config"][
+                "organization_pk"
+            ]
+        )
+        assertContains(response, "Sync queued")
+
+    def test_sync_job_error(self, client, url, user, organization, mocker, all_mdms):
+        """When the Dagster job trigger fails, an error message is shown."""
+        MDM = get_active_mdm_class()
+        mock_sync_fleet = mocker.patch.object(MDM, "sync_fleet")
+        dagster_error = Exception("Dagster unreachable")
+        mocker.patch(
+            "apps.publish_mdm.views.trigger_dagster_job",
+            side_effect=dagster_error,
+        )
+        FleetFactory.create_batch(2, organization=organization)
+
+        response = client.post(url, data={"sync": 1})
+
+        mock_sync_fleet.assert_not_called()
+        assertContains(
+            response,
+            "Unable to queue syncing due to the following error:"
+            f'<pre class="block text-xs mt-2">{dagster_error}</pre>',
+        )
 
     def check_list_after_searching_or_filtering(self, response, matching_devices):
         assert response.status_code == 200
@@ -3173,7 +3128,9 @@ class TestDeviceUpdateAppUser(ViewTestBase, TestAllMDMsNoAutouse):
         mocker,
         set_mdm_env_vars,
     ):
-        """Ensure submitting a valid form updates the Device's app_user_name."""
+        """Ensure submitting a valid form updates the Device's app_user_name and
+        triggers a Dagster job.
+        """
         if app_user_name:
             AppUserFactory(name=app_user_name, project=device.fleet.project)
         data = {
@@ -3181,13 +3138,18 @@ class TestDeviceUpdateAppUser(ViewTestBase, TestAllMDMsNoAutouse):
         }
         MDM = get_active_mdm_class()
         mock_push_device_config = mocker.patch.object(MDM, "push_device_config")
+        mock_trigger = mocker.patch("apps.publish_mdm.views.trigger_dagster_job")
         response = client.post(url, data=data, follow=True)
         form = response.context.get("form")
         assert isinstance(form, DeviceAppUserForm)
         assert not form.errors, form.errors
         device.refresh_from_db()
         assert device.app_user_name == app_user_name
-        mock_push_device_config.assert_called_once_with(device)
+        mock_push_device_config.assert_not_called()
+        mock_trigger.assert_called_once_with(
+            job_name="mdm_job",
+            run_config={"ops": {"push_mdm_device_config": {"config": {"device_pks": [device.pk]}}}},
+        )
 
     def test_invalid_form(self, client, url, user, device):
         """Ensure submitting an invalid form doesn't update the Device's app_user_name
@@ -3208,32 +3170,38 @@ class TestDeviceUpdateAppUser(ViewTestBase, TestAllMDMsNoAutouse):
         assert device.app_user_name != app_user_name
         assertContains(response, expected_error_message)
 
-    def test_push_device_config_called_on_valid_form(self, client, url, user, device, mocker):
-        """After a valid app_user change, push_device_config is called immediately."""
+    def test_dagster_job_triggered_on_valid_form(self, client, url, user, device, mocker):
+        """After a valid app_user change, mdm_job is triggered via Dagster."""
         mock_mdm = mocker.MagicMock()
         mocker.patch("apps.publish_mdm.views.get_active_mdm_instance", return_value=mock_mdm)
+        mock_trigger = mocker.patch("apps.publish_mdm.views.trigger_dagster_job")
         AppUserFactory(name="pushed_user", project=device.fleet.project)
         client.post(url, data={"app_user_name": "pushed_user"})
         device.refresh_from_db()
         assert device.app_user_name == "pushed_user"
-        mock_mdm.push_device_config.assert_called_once()
-        pushed_device = mock_mdm.push_device_config.call_args[0][0]
-        assert pushed_device.pk == device.pk
+        mock_mdm.push_device_config.assert_not_called()
+        mock_trigger.assert_called_once_with(
+            job_name="mdm_job",
+            run_config={"ops": {"push_mdm_device_config": {"config": {"device_pks": [device.pk]}}}},
+        )
 
-    def test_push_device_config_not_called_on_invalid_form(self, client, url, user, device, mocker):
-        """push_device_config is not called when the form is invalid."""
+    def test_dagster_job_not_triggered_on_invalid_form(self, client, url, user, device, mocker):
+        """trigger_dagster_job is not called when the form is invalid."""
         mock_mdm = mocker.MagicMock()
         mocker.patch("apps.publish_mdm.views.get_active_mdm_instance", return_value=mock_mdm)
+        mock_trigger = mocker.patch("apps.publish_mdm.views.trigger_dagster_job")
         client.post(url, data={"app_user_name": "nonexistent_user"})
         mock_mdm.push_device_config.assert_not_called()
+        mock_trigger.assert_not_called()
 
-    def test_push_device_config_error_does_not_break_response(
-        self, client, url, user, device, mocker
-    ):
-        """An exception from push_device_config is logged but the view still returns 200."""
+    def test_dagster_job_error_does_not_break_response(self, client, url, user, device, mocker):
+        """An exception from trigger_dagster_job is logged but the view still returns 200."""
         mock_mdm = mocker.MagicMock()
-        mock_mdm.push_device_config.side_effect = Exception("MDM error")
         mocker.patch("apps.publish_mdm.views.get_active_mdm_instance", return_value=mock_mdm)
+        mocker.patch(
+            "apps.publish_mdm.views.trigger_dagster_job",
+            side_effect=Exception("Dagster error"),
+        )
         AppUserFactory(name="some_user", project=device.fleet.project)
         response = client.post(url, data={"app_user_name": "some_user"})
         assert response.status_code == 200

--- a/tests/publish_mdm/test_views.py
+++ b/tests/publish_mdm/test_views.py
@@ -2331,8 +2331,8 @@ class TestDevicesList(ViewTestBase, TestAllMDMsNoAutouse):
         mock_sync_fleet.assert_not_called()
         assertContains(
             response,
-            "Unable to queue syncing due to the following error:"
-            f'<pre class="block text-xs mt-2">{dagster_error}</pre>',
+            "We encountered an issue synchronizing your device list. "
+            "Please try again, or contact support if the problem continues.",
         )
 
     def check_list_after_searching_or_filtering(self, response, matching_devices):


### PR DESCRIPTION
This PR routes MDM device syncing and pushing of device configs through Dagster to prevent blocking the request/response cycle.