### PR TITLE
fix(mdm): Create default policy in MDM when it's created in the DB

### DIFF
--- a/apps/mdm/views.py
+++ b/apps/mdm/views.py
@@ -9,7 +9,6 @@ from django.db.models import F, Max, Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.crypto import get_random_string
-from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
@@ -234,9 +233,8 @@ def policy_add(request, organization_slug):
         if form.is_valid():
             policy = form.save(commit=False)
             policy.mdm = settings.ACTIVE_MDM["name"]
-            # policy_id: "policy_" (7) + up to 50 chars of slug + "_" (1) + 8 random chars = ≤66 chars,
-            # well within the 255-char field limit; random suffix prevents collisions.
-            policy.policy_id = f"policy_{slugify(policy.name)[:50]}_{get_random_string(8)}"
+            # Create a random policy ID to avoid collisions.
+            policy.policy_id = f"policy_{get_random_string(20)}"
             policy.organization = request.organization
             policy.save()
             PolicyApplication.objects.create(

--- a/apps/publish_mdm/models.py
+++ b/apps/publish_mdm/models.py
@@ -69,7 +69,8 @@ class Organization(AbstractBaseModel):
         # Create an org-specific default policy
         policy = Policy.all_mdms.create(
             name="Default",
-            policy_id=f"policy_default_{get_random_string(12)}",
+            # Create a random policy ID to avoid collisions.
+            policy_id=f"policy_{get_random_string(20)}",
             mdm=settings.ACTIVE_MDM["name"],
             organization=self,
         )

--- a/apps/publish_mdm/models.py
+++ b/apps/publish_mdm/models.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.validators import RegexValidator
-from django.db import models
+from django.db import models, transaction
 from django.db.models import F, Value
 from django.db.models.functions import NullIf
 from django.urls import reverse
@@ -66,29 +66,30 @@ class Organization(AbstractBaseModel):
         active_mdm = get_active_mdm_instance(organization=self)
         if not active_mdm:
             return None
-        # Create an org-specific default policy
-        policy = Policy.all_mdms.create(
-            name="Default",
-            # Create a random policy ID to avoid collisions.
-            policy_id=f"policy_{get_random_string(20)}",
-            mdm=settings.ACTIVE_MDM["name"],
-            organization=self,
-        )
-        # Create the pinned ODK Collect app row (order=0) so new policies are consistent
-        # with those created via the policy editor UI.
-        PolicyApplication.objects.create(
-            policy=policy,
-            package_name=policy.odk_collect_package,
-            install_type="FORCE_INSTALLED",
-            order=0,
-        )
-        # Ensure the default policy exists in the MDM before linking groups to it.
-        active_mdm.create_or_update_policy(policy)
-        fleet = Fleet(organization=self, name="Default", policy=policy)
-        active_mdm.create_group(fleet)
-        active_mdm.add_group_to_policy(fleet)
-        active_mdm.get_enrollment_qr_code(fleet)
-        fleet.save()
+        with transaction.atomic():
+            # Create an org-specific default policy
+            policy = Policy.all_mdms.create(
+                name="Default",
+                # Create a random policy ID to avoid collisions.
+                policy_id=f"policy_{get_random_string(20)}",
+                mdm=settings.ACTIVE_MDM["name"],
+                organization=self,
+            )
+            # Create the pinned ODK Collect app row (order=0) so new policies are consistent
+            # with those created via the policy editor UI.
+            PolicyApplication.objects.create(
+                policy=policy,
+                package_name=policy.odk_collect_package,
+                install_type="FORCE_INSTALLED",
+                order=0,
+            )
+            # Ensure the default policy exists in the MDM before linking groups to it.
+            active_mdm.create_or_update_policy(policy)
+            fleet = Fleet(organization=self, name="Default", policy=policy)
+            active_mdm.create_group(fleet)
+            active_mdm.add_group_to_policy(fleet)
+            active_mdm.get_enrollment_qr_code(fleet)
+            fleet.save()
         return fleet
 
 

--- a/apps/publish_mdm/models.py
+++ b/apps/publish_mdm/models.py
@@ -81,6 +81,11 @@ class Organization(AbstractBaseModel):
             install_type="FORCE_INSTALLED",
             order=0,
         )
+        # Ensure the default policy exists in the MDM
+        try:
+            active_mdm.create_or_update_policy(policy)
+        except Exception:
+            logger.error("Failed to push default policy to MDM", policy=policy, exc_info=True)
         fleet = Fleet(organization=self, name="Default", policy=policy)
         active_mdm.create_group(fleet)
         active_mdm.add_group_to_policy(fleet)

--- a/apps/publish_mdm/models.py
+++ b/apps/publish_mdm/models.py
@@ -82,11 +82,8 @@ class Organization(AbstractBaseModel):
             install_type="FORCE_INSTALLED",
             order=0,
         )
-        # Ensure the default policy exists in the MDM
-        try:
-            active_mdm.create_or_update_policy(policy)
-        except Exception:
-            logger.error("Failed to push default policy to MDM", policy=policy, exc_info=True)
+        # Ensure the default policy exists in the MDM before linking groups to it.
+        active_mdm.create_or_update_policy(policy)
         fleet = Fleet(organization=self, name="Default", policy=policy)
         active_mdm.create_group(fleet)
         active_mdm.add_group_to_policy(fleet)

--- a/tests/publish_mdm/test_models.py
+++ b/tests/publish_mdm/test_models.py
@@ -324,6 +324,29 @@ class TestOrganization(TestAllMDMs):
         mock_add_group_to_policy.assert_called_once()
         mock_get_enrollment_qr_code.assert_called_once()
 
+    def test_create_default_fleet_raises_if_policy_sync_fails(
+        self, set_mdm_env_vars, mocker, settings
+    ):
+        """Default fleet creation should fail fast when policy sync fails."""
+        organization = OrganizationFactory()
+        if settings.ACTIVE_MDM["name"] == "Android Enterprise":
+            AndroidEnterpriseAccountFactory(
+                organization=organization, enterprise_name="enterprises/test"
+            )
+        MDM = get_active_mdm_class()
+        mocker.patch.object(MDM, "create_or_update_policy", side_effect=RuntimeError("sync failed"))
+        mock_create_group = mocker.patch.object(MDM, "create_group")
+        mock_add_group_to_policy = mocker.patch.object(MDM, "add_group_to_policy")
+        mock_get_enrollment_qr_code = mocker.patch.object(MDM, "get_enrollment_qr_code")
+        mocker.patch.object(MDM, "pull_devices")
+
+        with pytest.raises(RuntimeError, match="sync failed"):
+            organization.create_default_fleet()
+
+        mock_create_group.assert_not_called()
+        mock_add_group_to_policy.assert_not_called()
+        mock_get_enrollment_qr_code.assert_not_called()
+
     def test_create_default_fleet_policy_id_is_unique(self, set_mdm_env_vars, mocker, settings):
         """Two calls to create_default_fleet() must produce distinct policy_id values.
 

--- a/tests/publish_mdm/test_models.py
+++ b/tests/publish_mdm/test_models.py
@@ -8,6 +8,7 @@ from django.db.utils import IntegrityError
 from apps.infisical.api import InfisicalKMS
 from apps.infisical.fields import EncryptedMixin
 from apps.mdm.mdms import get_active_mdm_class
+from apps.mdm.models import Fleet, Policy, PolicyApplication
 from apps.publish_mdm.etl import template
 from apps.publish_mdm.models import CentralServer
 from tests.mdm import TestAllMDMs
@@ -327,7 +328,9 @@ class TestOrganization(TestAllMDMs):
     def test_create_default_fleet_raises_if_policy_sync_fails(
         self, set_mdm_env_vars, mocker, settings
     ):
-        """Default fleet creation should fail fast when policy sync fails."""
+        """Default fleet creation should fail fast when policy sync fails, and
+        DB rows (Policy, PolicyApplication) should be rolled back atomically.
+        """
         organization = OrganizationFactory()
         if settings.ACTIVE_MDM["name"] == "Android Enterprise":
             AndroidEnterpriseAccountFactory(
@@ -346,6 +349,10 @@ class TestOrganization(TestAllMDMs):
         mock_create_group.assert_not_called()
         mock_add_group_to_policy.assert_not_called()
         mock_get_enrollment_qr_code.assert_not_called()
+        # The atomic block should have rolled back all DB changes.
+        assert not Policy.all_mdms.filter(organization=organization).exists()
+        assert not PolicyApplication.objects.filter(policy__organization=organization).exists()
+        assert not Fleet.objects.filter(organization=organization).exists()
 
     def test_create_default_fleet_policy_id_is_unique(self, set_mdm_env_vars, mocker, settings):
         """Two calls to create_default_fleet() must produce distinct policy_id values.

--- a/tests/publish_mdm/test_models.py
+++ b/tests/publish_mdm/test_models.py
@@ -308,6 +308,7 @@ class TestOrganization(TestAllMDMs):
                 organization=organization, enterprise_name="enterprises/test"
             )
         MDM = get_active_mdm_class()
+        mock_create_or_update_policy = mocker.patch.object(MDM, "create_or_update_policy")
         mock_create_group = mocker.patch.object(MDM, "create_group")
         mock_add_group_to_policy = mocker.patch.object(MDM, "add_group_to_policy")
         mock_get_enrollment_qr_code = mocker.patch.object(MDM, "get_enrollment_qr_code")
@@ -318,6 +319,7 @@ class TestOrganization(TestAllMDMs):
         assert fleet.name == "Default"
         assert fleet.policy.organization == organization
         assert fleet.policy.name == "Default"
+        mock_create_or_update_policy.assert_called_once_with(fleet.policy)
         mock_create_group.assert_called_once()
         mock_add_group_to_policy.assert_called_once()
         mock_get_enrollment_qr_code.assert_called_once()
@@ -330,6 +332,7 @@ class TestOrganization(TestAllMDMs):
         under concurrency or after deletions.
         """
         MDM = get_active_mdm_class()
+        mock_create_or_update_policy = mocker.patch.object(MDM, "create_or_update_policy")
         mocker.patch.object(MDM, "create_group")
         mocker.patch.object(MDM, "add_group_to_policy")
         mocker.patch.object(MDM, "get_enrollment_qr_code")
@@ -343,3 +346,4 @@ class TestOrganization(TestAllMDMs):
         fleet1 = org1.create_default_fleet()
         fleet2 = org2.create_default_fleet()
         assert fleet1.policy.policy_id != fleet2.policy.policy_id
+        assert mock_create_or_update_policy.call_count == 2


### PR DESCRIPTION
Closes #143 

Also, remove the policy name slug from the `policy_id` for AMAPI to standardize their format.