### PR TITLE
feat(mdm): Improve policy list page styling

### DIFF
--- a/apps/mdm/tables.py
+++ b/apps/mdm/tables.py
@@ -1,0 +1,25 @@
+from typing import ClassVar
+
+import django_tables2 as tables
+
+from .models import Policy
+
+
+class PolicyTable(tables.Table):
+    """A table for listing MDM Policies."""
+
+    name = tables.LinkColumn(
+        "mdm:policy-edit",
+        args=[tables.A("organization__slug"), tables.A("pk")],
+        attrs={"a": {"class": "text-primary-600 hover:underline"}},
+    )
+    policy_id = tables.Column(verbose_name="Policy ID")
+    fleet_count = tables.Column(verbose_name="Fleets", orderable=False)
+
+    class Meta:
+        model = Policy
+        fields = ("name", "policy_id", "fleet_count")
+        template_name = "patterns/tables/table.html"
+        attrs: ClassVar = {"th": {"scope": "col", "class": "px-4 py-3 whitespace-nowrap"}}
+        orderable = False
+        empty_text = 'No policies found. Click "Add policy" to create one.'

--- a/apps/mdm/views.py
+++ b/apps/mdm/views.py
@@ -5,12 +5,13 @@ import structlog
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.db.models import F, Max, Q
+from django.db.models import Count, F, Max, Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.crypto import get_random_string
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django_tables2.config import RequestConfig
 
 from apps.publish_mdm.models import AndroidEnterpriseAccount
 from apps.publish_mdm.nav import Breadcrumbs
@@ -32,6 +33,7 @@ from .models import (
     PolicyVariable,
     PolicyVariableScope,
 )
+from .tables import PolicyTable
 
 logger = structlog.get_logger()
 
@@ -214,10 +216,14 @@ def _push_policy_to_mdm(policy, request):
 @login_required
 def policy_list(request, organization_slug):
     """List all policies for the current organization."""
-    policies = Policy.objects.filter(organization=request.organization)
+    policies = Policy.objects.filter(organization=request.organization).annotate(
+        fleet_count=Count("fleets")
+    )
+    exclude = ("policy_id",) if request.organization.mdm == "Android Enterprise" else ()
+    table = PolicyTable(data=policies, exclude=exclude)
+    RequestConfig(request, paginate=False).configure(table)
     context = {
-        "policies": policies,
-        "show_policy_id": request.organization.mdm != "Android Enterprise",
+        "table": table,
         "breadcrumbs": Breadcrumbs.from_items(
             request=request,
             items=[("Policies", "mdm:policy-list")],

--- a/config/templates/mdm/policy_list.html
+++ b/config/templates/mdm/policy_list.html
@@ -11,38 +11,9 @@
             </a>
         </div>
     {% endif %}
-    <div class="mb-4 items-end justify-between space-y-4 sm:flex">
+    <div class="mb-4 items-end justify-between space-y-4 sm:flex sm:space-y-0 md:mb-8">
         <a href="{% url 'mdm:policy-add' request.organization.slug %}"
            class="btn btn-outline mr-4">Add policy</a>
     </div>
-    <div class="bg-white sm:rounded-md overflow-x-auto dark:bg-gray-800">
-        <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-            <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
-                <tr>
-                    <th scope="col" class="px-4 py-3 whitespace-nowrap">Name</th>
-                    {% if show_policy_id %}<th scope="col" class="px-4 py-3 whitespace-nowrap">Policy ID</th>{% endif %}
-                    <th scope="col" class="px-4 py-3 whitespace-nowrap"></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for policy in policies %}
-                    <tr class="border-b dark:border-gray-700">
-                        <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">{{ policy.name }}</td>
-                        {% if show_policy_id %}<td class="px-4 py-3">{{ policy.policy_id }}</td>{% endif %}
-                        <td class="px-4 py-3">
-                            <a href="{% url 'mdm:policy-edit' request.organization.slug policy.pk %}"
-                               class="text-primary-600 hover:underline dark:text-primary-400">Edit</a>
-                        </td>
-                    </tr>
-                {% empty %}
-                    <tr class="border-b dark:border-gray-700">
-                        <td colspan="{% if show_policy_id %}3{% else %}2{% endif %}"
-                            class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-                            No policies found. Click "Add policy" to create one.
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+    {% include "patterns/tables/table-partial.html" %}
 {% endblock content %}

--- a/tests/mdm/test_views.py
+++ b/tests/mdm/test_views.py
@@ -64,8 +64,32 @@ class TestPolicyList(PolicyViewBase, TestAllMDMs):
     def test_lists_org_policies(self, client, url, policy, other_org_policy):
         response = client.get(url)
         assert response.status_code == 200
-        assert policy in response.context["policies"]
-        assert other_org_policy not in response.context["policies"]
+        table_data = list(response.context["table"].data)
+        assert policy in table_data
+        assert other_org_policy not in table_data
+
+    def test_name_links_to_edit_page(self, client, url, organization, policy):
+        response = client.get(url)
+        edit_url = reverse("mdm:policy-edit", args=[organization.slug, policy.pk])
+        assertContains(response, f'href="{edit_url}"')
+
+    def test_fleet_count_column(self, client, url, organization, policy):
+        FleetFactory(policy=policy, organization=organization)
+        FleetFactory(policy=policy, organization=organization)
+        response = client.get(url)
+        assert response.status_code == 200
+        rows = list(response.context["table"].as_values())
+        # First row is headers, second is the policy row
+        policy_row = dict(zip(rows[0], rows[1], strict=True))
+        assert policy_row["Fleets"] == 2
+
+    def test_policy_id_column_visibility(self, client, url):
+        response = client.get(url)
+        assert response.status_code == 200
+        if self.mdm == "Android Enterprise":
+            assert "Policy ID" not in response.content.decode()
+        else:
+            assertContains(response, "Policy ID")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mdm/test_views.py
+++ b/tests/mdm/test_views.py
@@ -83,13 +83,33 @@ class TestPolicyList(PolicyViewBase, TestAllMDMs):
         policy_row = dict(zip(rows[0], rows[1], strict=True))
         assert policy_row["Fleets"] == 2
 
-    def test_policy_id_column_visibility(self, client, url):
+
+# ---------------------------------------------------------------------------
+# policy_list — MDM-specific column visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPolicyListAndroidEnterprise(PolicyViewBase, TestAndroidEnterpriseOnly):
+    @pytest.fixture
+    def url(self, organization):
+        return reverse("mdm:policy-list", args=[organization.slug])
+
+    def test_policy_id_column_hidden(self, client, url):
         response = client.get(url)
         assert response.status_code == 200
-        if self.mdm == "Android Enterprise":
-            assert "Policy ID" not in response.content.decode()
-        else:
-            assertContains(response, "Policy ID")
+        assert "Policy ID" not in response.content.decode()
+
+
+@pytest.mark.django_db
+class TestPolicyListTinyMDM(PolicyViewBase, TestTinyMDMOnly):
+    @pytest.fixture
+    def url(self, organization):
+        return reverse("mdm:policy-list", args=[organization.slug])
+
+    def test_policy_id_column_shown(self, client, url):
+        response = client.get(url)
+        assertContains(response, "Policy ID")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves the styling of the policy list page to match the other list pages.

## Before
<img width="1049" height="282" alt="Screenshot 2026-04-22 at 10 02 00 PM" src="https://github.com/user-attachments/assets/55bf4395-beb1-445f-9f0c-54c0f1de8e51" />

## After
<img width="1048" height="286" alt="Screenshot 2026-04-22 at 10 01 43 PM" src="https://github.com/user-attachments/assets/f073ff6c-deee-4e44-a933-10a084ea10af" />
