### PR TITLE
fix: Default `CONN_MAX_AGE` to zero for ASGI

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -134,10 +134,12 @@ WSGI_APPLICATION = "config.wsgi.application"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
 # https://docs.djangoproject.com/en/5.2/ref/settings/#conn-max-age
-# Default to 60s to avoid holding connections open indefinitely.
-# None (unlimited) without health checks risks 500 errors on stale connections.
+# Persistent connections are not safe for ASGI (concurrent requests on one thread).
+# Default to 0 for ASGI/Daphne workers, 60 for WSGI/Gunicorn workers.
+# Can be overridden via DATABASE_CONN_MAX_AGE env var for specific deployments.
 _conn_max_age_env = os.getenv("DATABASE_CONN_MAX_AGE")
-CONN_MAX_AGE = int(_conn_max_age_env) if _conn_max_age_env is not None else 60
+_default_conn_max_age = 60 if os.getenv("USE_GUNICORN") else 0
+CONN_MAX_AGE = int(_conn_max_age_env) if _conn_max_age_env is not None else _default_conn_max_age
 # https://docs.djangoproject.com/en/5.2/ref/settings/#conn-health-checks
 CONN_HEALTH_CHECKS = os.getenv("DATABASE_CONN_HEALTH_CHECKS", "True") == "True"
 DATABASES = {


### PR DESCRIPTION
According to the [documentation](https://docs.djangoproject.com/en/5.2/ref/databases/#persistent-database-connections),

> When using ASGI, persistent connections should be disabled. Instead, use your database backend’s built-in connection pooling if available, or investigate a third-party connection pooling option if required.

**ASGI deployments:**
```
$ python manage.py shell -c "from django.conf import settings; print(settings.DATABASES)"           
42 objects imported automatically (use -v 2 for details).

{'default': {'ENGINE': 'django.db.backends.postgresql', 'USER': 'tobias', 'PASSWORD': '', 'HOST': 'localhost', 'PORT': 5432, 'NAME': 'odk_publish', 'CONN_MAX_AGE': 0, 'CONN_HEALTH_CHECKS': True, 'DISABLE_SERVER_SIDE_CURSORS': False, 'ATOMIC_REQUESTS': False, 'AUTOCOMMIT': True, 'OPTIONS': {}, 'TIME_ZONE': None, 'TEST': {'CHARSET': None, 'COLLATION': None, 'MIGRATE': True, 'MIRROR': None, 'NAME': None}}}
```

**Gunicorn deployments:**
```
$ USE_GUNICORN=true python manage.py shell -c "from django.conf import settings; print(settings.DATABASES)"
42 objects imported automatically (use -v 2 for details).

{'default': {'ENGINE': 'django.db.backends.postgresql', 'USER': 'tobias', 'PASSWORD': '', 'HOST': 'localhost', 'PORT': 5432, 'NAME': 'odk_publish', 'CONN_MAX_AGE': 60, 'CONN_HEALTH_CHECKS': True, 'DISABLE_SERVER_SIDE_CURSORS': False, 'ATOMIC_REQUESTS': False, 'AUTOCOMMIT': True, 'OPTIONS': {}, 'TIME_ZONE': None, 'TEST': {'CHARSET': None, 'COLLATION': None, 'MIGRATE': True, 'MIRROR': None, 'NAME': None}}}
```