### PR TITLE
fix: Remove the ability to restore soft-deleted devices.

### DIFF
--- a/apps/mdm/admin.py
+++ b/apps/mdm/admin.py
@@ -409,7 +409,7 @@ class DeviceAdmin(ImportExportMixin, admin.ModelAdmin):
     confirm_form_class = DeviceConfirmImportForm
     export_form_class = ExportForm
     resource_classes = (DeviceResource,)
-    actions: ClassVar = ["wipe_and_soft_delete_devices", "restore_devices"]
+    actions: ClassVar = ["wipe_and_soft_delete_devices"]
 
     def save_model(self, request, obj, form, change):
         """Always push to MDM when saving a Device in the admin."""
@@ -451,11 +451,6 @@ class DeviceAdmin(ImportExportMixin, admin.ModelAdmin):
                 f"{failed} device(s) could not be wiped and deleted.",
                 level=messages.ERROR,
             )
-
-    @admin.action(description="Restore selected devices")
-    def restore_devices(self, request, queryset):
-        count = queryset.filter(deleted_at__isnull=False).restore()
-        self.message_user(request, f"{count} device(s) restored.")
 
     def get_import_data_kwargs(self, request, *args, **kwargs):
         """Prepare kwargs for import_data."""

--- a/tests/mdm/test_admin.py
+++ b/tests/mdm/test_admin.py
@@ -892,25 +892,3 @@ class TestDeviceAdminWipeAndSoftDelete(TestAdmin):
         device.refresh_from_db()
         assert device.is_deleted is False
         assertContains(response, "1 device(s) could not be wiped and deleted.")
-
-    def test_restore_action(self, client, user, device):
-        """The restore_devices action clears deleted_at."""
-        device.soft_delete()
-        data = {
-            "action": "restore_devices",
-            "_selected_action": [device.pk],
-        }
-        response = client.post(reverse("admin:mdm_device_changelist"), data, follow=True)
-        assert response.status_code == 200
-        device.refresh_from_db()
-        assert device.is_deleted is False
-
-    def test_restore_action_skips_active_devices(self, client, user, device):
-        """Restore on an active (non-deleted) device reports 0 affected."""
-        data = {
-            "action": "restore_devices",
-            "_selected_action": [device.pk],
-        }
-        response = client.post(reverse("admin:mdm_device_changelist"), data, follow=True)
-        assert response.status_code == 200
-        assertContains(response, "0 device(s) restored")


### PR DESCRIPTION
This PR removes the ability to restore soft-deleted devices in Admin. When a Device is soft-deleted either through its detail page or Admin, it gets factory-reset (if fully managed) or the work profile is deleted from the device, which deletes the device from the MDM. It therefore no longer makes sense to have the ability to restore a soft-deleted device in our database since such a device will no longer exist in the MDM, and the next time devices are synced the device would automatically get soft-deleted again anyway.