### PR TITLE
feat: Add Android Enterprise enrollment details to the Account Settings page.

### DIFF
--- a/apps/publish_mdm/views.py
+++ b/apps/publish_mdm/views.py
@@ -3,6 +3,7 @@ import json
 from urllib.parse import urlencode
 
 import structlog
+from allauth.socialaccount.views import ConnectionsView
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import logout
@@ -1526,3 +1527,16 @@ def enterprise_callback(request: HttpRequest, callback_token):
         )
 
     return redirect(redirect_to)
+
+
+class SocialAccountConnectionsView(ConnectionsView):
+    """Extend allauth ConnectionsView to add Android Enterprise organizations to context."""
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["android_enterprise_organizations"] = (
+            self.request.user.get_organizations()
+            .filter(mdm="Android Enterprise")
+            .select_related("android_enterprise")
+        )
+        return context

--- a/config/templates/socialaccount/connections.html
+++ b/config/templates/socialaccount/connections.html
@@ -2,53 +2,160 @@
 {% load i18n %}
 {% load socialaccount %}
 {% block content %}
-    <div class="flex items-center justify-center transition-colors duration-300">
-        <div class="w-full max-w-md p-6 bg-white dark:bg-gray-800 rounded-lg shadow-md">
-            <h2 class="text-2xl font-bold text-center text-gray-800 dark:text-white">Account Connections</h2>
-            <p class="text-gray-600 dark:text-gray-400 text-center mt-2">Manage your linked third-party accounts.</p>
-            {% if form.accounts %}
-                <form method="post"
-                      action="{% url 'socialaccount_connections' %}"
-                      class="mt-4 space-y-4">
-                    {% for error in form.non_field_errors %}
-                        <div class="alert text-sm p-3 rounded-lg text-red bg-red-50 dark:bg-gray-800 dark:text-red-400"
-                             role="alert">{{ error }}</div>
-                    {% endfor %}
-                    {% csrf_token %}
-                    {% with num_accounts=form.fields.account.choices|length %}
-                        {% for acc in form.fields.account.choices %}
-                            {% with account=acc.0.instance.get_provider_account %}
-                                <div class="flex items-center justify-between  p-3 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                                    <span class="text-gray-800 dark:text-gray-200 font-medium">{{ account }}</span>
-                                    {% if num_accounts != 1 %}
-                                        <button name="account"
-                                                value="{{ account.account.pk }}"
-                                                class="text-red-500 hover:text-red-700 text-sm cursor-pointer">
-                                            Remove
-                                        </button>
-                                    {% endif %}
-                                </div>
-                            {% endwith %}
-                        {% endfor %}
-                    {% endwith %}
-                </form>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">Account Settings</h1>
+    <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
+        <ul class="flex flex-wrap gap-4 -mb-px text-base font-medium text-center text-gray-500 dark:text-gray-400"
+            id="account-settings-tabs"
+            data-tabs-toggle="#account-settings-tabs-content"
+            data-tabs-active-classes="text-primary-600 hover:text-primary-600 border-primary-600 dark:text-primary-400 dark:border-primary-400"
+            data-tabs-inactive-classes="border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300"
+            role="tablist">
+            <li class="me-2" role="presentation">
+                <button class="inline-block py-4 px-1 border-b-2 rounded-t-lg text-primary-600 border-primary-600 dark:text-primary-400 dark:border-primary-400"
+                        id="connected-accounts-tab"
+                        data-tabs-target="#connected-accounts"
+                        type="button"
+                        role="tab"
+                        aria-controls="connected-accounts"
+                        aria-selected="true">Connected Accounts</button>
+            </li>
+            {% if android_enterprise_organizations %}
+                <li class="me-2" role="presentation">
+                    <button class="inline-block py-4 px-1 border-b-2 rounded-t-lg"
+                            id="android-enterprise-tab"
+                            data-tabs-target="#android-enterprise"
+                            type="button"
+                            role="tab"
+                            aria-controls="android-enterprise"
+                            aria-selected="false">Android Enterprise Enrollment</button>
+                </li>
             {% endif %}
-            <div class="mt-6">
+        </ul>
+    </div>
+    <div id="account-settings-tabs-content">
+        {# Connected Accounts tab #}
+        <div id="connected-accounts"
+             role="tabpanel"
+             aria-labelledby="connected-accounts-tab">
+            <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 max-w-2xl">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-1">Connected Accounts</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-400 mb-5">Manage your linked third-party accounts.</p>
+                {% if form.accounts %}
+                    <form method="post"
+                          action="{% url 'socialaccount_connections' %}"
+                          class="space-y-3 mb-5">
+                        {% csrf_token %}
+                        {% for error in form.non_field_errors %}
+                            <div class="text-sm p-3 rounded-lg text-red-700 bg-red-50 dark:bg-gray-800 dark:text-red-400"
+                                 role="alert">{{ error }}</div>
+                        {% endfor %}
+                        {% with num_accounts=form.fields.account.choices|length %}
+                            {% for acc in form.fields.account.choices %}
+                                {% with account=acc.0.instance.get_provider_account %}
+                                    <div class="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-700 rounded-lg">
+                                        <div>
+                                            <p class="text-sm font-medium text-gray-900 dark:text-white">{{ account }}</p>
+                                            <p class="text-xs text-gray-500 dark:text-gray-400">{{ account.account.provider|capfirst }}</p>
+                                        </div>
+                                        {% if num_accounts != 1 %}
+                                            <button name="account"
+                                                    value="{{ account.account.pk }}"
+                                                    class="text-sm text-red-500 hover:text-red-700 dark:hover:text-red-400 cursor-pointer">
+                                                Remove
+                                            </button>
+                                        {% endif %}
+                                    </div>
+                                {% endwith %}
+                            {% endfor %}
+                        {% endwith %}
+                    </form>
+                {% endif %}
                 <a href="{% provider_login_url 'google' process='connect' %}"
                    class="w-full flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-lg shadow-md transition duration-300">
-                    <svg class="w-5 h-5 mr-2" viewBox="0 0 48 48">
-                        <path fill="#4285F4" d="M24 9.5c3.54 0 6.67 1.22 9.19 3.25l6.85-6.85C35.91 2.15 30.3 0 24 0 14.66 0 6.67 5.35 2.8 13.16l8.07 6.27C13.11 12.65 18.11 9.5 24 9.5z">
-                        </path>
-                        <path fill="#34A853" d="M46.14 24.46c0-1.6-.14-3.13-.4-4.6H24v9.39h12.51c-.58 3.03-2.21 5.63-4.69 7.39l7.49 5.83c4.41-4.07 6.97-10.07 6.97-17.01z">
-                        </path>
-                        <path fill="#FBBC05" d="M11.2 28.63c-1.66-4.99-1.66-10.37 0-15.36L3.13 6.9C-1.04 13.28-1.04 22.68 3.13 29.06l8.07-6.27z">
-                        </path>
-                        <path fill="#EA4335" d="M24 48c6.3 0 11.71-2.1 15.62-5.7l-7.49-5.83c-2.1 1.42-4.75 2.27-8.13 2.27-5.89 0-10.89-3.15-13.13-7.8l-8.07 6.27C6.67 42.65 14.66 48 24 48z">
-                        </path>
+                    <svg class="w-5 h-5 mr-2 shrink-0" viewBox="0 0 48 48" aria-hidden="true">
+                        <path fill="#4285F4" d="M24 9.5c3.54 0 6.67 1.22 9.19 3.25l6.85-6.85C35.91 2.15 30.3 0 24 0 14.66 0 6.67 5.35 2.8 13.16l8.07 6.27C13.11 12.65 18.11 9.5 24 9.5z" />
+                        <path fill="#34A853" d="M46.14 24.46c0-1.6-.14-3.13-.4-4.6H24v9.39h12.51c-.58 3.03-2.21 5.63-4.69 7.39l7.49 5.83c4.41-4.07 6.97-10.07 6.97-17.01z" />
+                        <path fill="#FBBC05" d="M11.2 28.63c-1.66-4.99-1.66-10.37 0-15.36L3.13 6.9C-1.04 13.28-1.04 22.68 3.13 29.06l8.07-6.27z" />
+                        <path fill="#EA4335" d="M24 48c6.3 0 11.71-2.1 15.62-5.7l-7.49-5.83c-2.1 1.42-4.75 2.27-8.13 2.27-5.89 0-10.89-3.15-13.13-7.8l-8.07 6.27C6.67 42.65 14.66 48 24 48z" />
                     </svg>
                     Add Google Account
                 </a>
             </div>
         </div>
+        {# Android Enterprise Enrollment tab #}
+        {% if android_enterprise_organizations %}
+            <div class="hidden"
+                 id="android-enterprise"
+                 role="tabpanel"
+                 aria-labelledby="android-enterprise-tab">
+                <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 max-w-2xl">
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-1">Android Enterprise Enrollment</h3>
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-5">
+                        The enrollment details for all your organizations that use the Android Enterprise MDM.
+                    </p>
+                    <div id="ae-enrollment-accordion"
+                         data-accordion="collapse"
+                         class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden shadow-xs">
+                        {% for org in android_enterprise_organizations %}
+                            <h2 id="ae-heading-{{ org.pk }}">
+                                <button type="button"
+                                        class="flex items-center justify-between w-full p-5 font-medium text-left text-gray-500 border-b border-gray-200 dark:border-gray-700 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 gap-3"
+                                        data-accordion-target="#ae-body-{{ org.pk }}"
+                                        aria-expanded="{% if org == request.organization %}true{% else %}false{% endif %}"
+                                        aria-controls="ae-body-{{ org.pk }}">
+                                    <span class="flex items-center gap-3">
+                                        {{ org.name }}
+                                        {% if org.android_enterprise.is_enrolled %}
+                                            <span class="inline-flex items-center bg-green-100 text-green-700 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">Enrolled</span>
+                                        {% else %}
+                                            <span class="inline-flex items-center bg-yellow-100 text-yellow-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-yellow-900 dark:text-yellow-300">Not enrolled</span>
+                                        {% endif %}
+                                    </span>
+                                    <svg data-accordion-icon
+                                         class="w-5 h-5 rotate-180 shrink-0"
+                                         aria-hidden="true"
+                                         xmlns="http://www.w3.org/2000/svg"
+                                         width="24"
+                                         height="24"
+                                         fill="none"
+                                         viewBox="0 0 24 24">
+                                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m5 15 7-7 7 7" />
+                                    </svg>
+                                </button>
+                            </h2>
+                            <div id="ae-body-{{ org.pk }}"
+                                 class="hidden"
+                                 aria-labelledby="ae-heading-{{ org.pk }}">
+                                <div class="p-5 border-b border-gray-200 dark:border-gray-700">
+                                    {% if org.android_enterprise.is_enrolled %}
+                                        <dl class="space-y-3">
+                                            <div class="sm:grid sm:grid-cols-3 sm:gap-4">
+                                                <dt class="text-sm font-medium text-gray-900 dark:text-white">Enterprise resource name</dt>
+                                                <dd class="mt-1 text-sm sm:col-span-2 sm:mt-0">
+                                                    <code class="font-mono text-sm text-gray-700 dark:text-gray-300 break-all">{{ org.android_enterprise.enterprise_name }}</code>
+                                                </dd>
+                                            </div>
+                                            <div class="sm:grid sm:grid-cols-3 sm:gap-4">
+                                                <dt class="text-sm font-medium text-gray-900 dark:text-white">Enrollment date</dt>
+                                                <dd class="mt-1 text-sm text-gray-700 dark:text-gray-300 sm:col-span-2 sm:mt-0">
+                                                    {{ org.android_enterprise.created_at|date:"N j, Y" }}
+                                                </dd>
+                                            </div>
+                                        </dl>
+                                    {% else %}
+                                        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">This organization is not enrolled.</p>
+                                        <a href="{% url 'publish_mdm:enterprise-setup' org.slug %}?next={{ request.get_full_path|urlencode }}"
+                                           class="btn btn-outline text-sm inline-block">Start enrollment</a>
+                                        <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                                            You will be redirected to enterprise.google.com to complete the Android Enterprise enrollment.
+                                        </p>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
     </div>
 {% endblock content %}

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,9 +20,18 @@ from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.generic import TemplateView
 
-from apps.publish_mdm.views import AcceptOrganizationInvite, websockets_server_health
+from apps.publish_mdm.views import (
+    AcceptOrganizationInvite,
+    SocialAccountConnectionsView,
+    websockets_server_health,
+)
 
 urlpatterns = [
+    path(
+        "accounts/3rdparty/",
+        SocialAccountConnectionsView.as_view(),
+        name="socialaccount_connections",
+    ),
     path("accounts/", include("allauth.urls")),
     path("admin/", admin.site.urls),
     path("", include("apps.publish_mdm.urls", namespace="publish_mdm")),

--- a/tests/publish_mdm/test_views.py
+++ b/tests/publish_mdm/test_views.py
@@ -72,6 +72,7 @@ from tests.mdm.factories import (
     PolicyFactory,
 )
 from tests.publish_mdm.factories import (
+    AndroidEnterpriseAccountFactory,
     AppUserFactory,
     AppUserFormTemplateFactory,
     AppUserFormVersionFactory,
@@ -3719,3 +3720,59 @@ class TestEnterpriseCallback(TestAndroidEnterpriseOnly):
         assertContains(response, "Android Enterprise enrollment completed successfully.")
         account.refresh_from_db()
         assert account.enterprise_name == "enterprises/LC00lvvue0"
+
+
+@pytest.mark.django_db
+class TestSocialAccountConnectionsView:
+    """Tests the SocialAccountConnectionsView at /accounts/3rdparty/."""
+
+    @pytest.fixture
+    def url(self):
+        return reverse("socialaccount_connections")
+
+    @pytest.fixture
+    def user(self, client):
+        user = UserFactory()
+        user.save()
+        client.force_login(user)
+        return user
+
+    def test_login_required(self, client, url, user):
+        """Unauthenticated requests are redirected to the login page."""
+        client.logout()
+        response = client.get(url)
+        assert response.status_code == 302
+
+    def test_get(self, client, url, user):
+        """All Android Enterprise organizations that the user belongs to should be added to the context."""
+        android_enterprise_organizations = OrganizationFactory.create_batch(
+            3, mdm="Android Enterprise"
+        )
+        user.organizations.set(android_enterprise_organizations)
+        # One of the orgs is enrolled
+        enrolled_android_enterprise = AndroidEnterpriseAccountFactory(
+            organization=android_enterprise_organizations[0], enterprise_name="enterprises/test123"
+        )
+        AndroidEnterpriseAccountFactory(organization=android_enterprise_organizations[1])
+        # An Android Enterprise org that the user does not belong to should not be included
+        OrganizationFactory(mdm="Android Enterprise")
+        # A TinyMDM org should not be included, even if the user belongs to it
+        OrganizationFactory(mdm="TinyMDM")
+        OrganizationFactory(mdm="TinyMDM").users.add(user)
+        response = client.get(url)
+        assert response.status_code == 200
+        assertQuerySetEqual(
+            response.context["android_enterprise_organizations"],
+            android_enterprise_organizations,
+        )
+        assertContains(response, enrolled_android_enterprise.enterprise_name)
+        # An enterprise setup link should be displayed for orgs that haven't enrolled yet,
+        # including the one that has a AndroidEnterpriseAccount but hasn't completed enrollment.
+        for org in android_enterprise_organizations[1:]:
+            assertContains(response, reverse("publish_mdm:enterprise-setup", args=[org.slug]))
+        assertNotContains(
+            response,
+            reverse(
+                "publish_mdm:enterprise-setup", args=[enrolled_android_enterprise.organization.slug]
+            ),
+        )


### PR DESCRIPTION
This PR adds a tab in the Account Settings page showing enrollment details for all the Android Enterprise organizations that the user belongs to. If there are no such organizations the tab is not displayed.

<img width="717" height="696" alt="image" src="https://github.com/user-attachments/assets/a88f5c7c-c3ee-424d-abd1-2249b9ae6998" />

For an organization that isn't enrolled, a button to start enrollment will be displayed:

<img width="677" height="686" alt="image" src="https://github.com/user-attachments/assets/d29ab403-8ea4-4378-af07-57175dc1eade" />


